### PR TITLE
feat: MCP integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- MCP integration: Booked now registers ~50 tools with the optional [craft-mcp](https://github.com/stimmtdigital/craft-mcp) plugin, exposing near-complete headless admin to AI assistants — services, employees, locations, schedules, blackout dates, service extras, availability, reservations, event dates, waitlist and reporting. Covers reads, create/update (soft-disable via `enabled` rather than hard delete), reschedule, quantity changes, refunds and analytics. The dependency is soft (`class_exists`-guarded) — Booked runs unchanged when craft-mcp is absent. Customer PII is redacted in bulk list output and booking capability tokens are never exposed. See [MCP.md](MCP.md).
+
 ## 1.1.1 - 2026-04-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 1.2.1 - 2026-06-17
+
+### Added
+- MCP authorization settings (Settings → Security): **Allow MCP write operations** (`mcpWriteEnabled`) and **Allow MCP refunds** (`mcpAllowRefunds`), both **off by default**. A migration adds the columns to existing installs.
+
+### Security
+- MCP write tools are now **default-deny**: every create/update/cancel/delete/refund tool is gated behind `mcpWriteEnabled` (and refunds additionally behind `mcpAllowRefunds`), rather than relying on the craft-mcp server config alone (this supersedes the 1.2.0 "authorization is delegated to the craft-mcp server" note). In a web context an authenticated user must also hold `booked-manageBookings`.
+- `booked_refund_reservation` is now idempotent — it nets out prior refunds and never refunds more than the outstanding (paid minus already-refunded) amount.
+- Customer PII (email/phone) is now redacted by default in all MCP responses — including create/update/booking responses, not just bulk lists — so a forgotten flag fails safe.
+- MCP list tools clamp their page size to a hard ceiling (200) to prevent unbounded result sets (memory exhaustion / bulk data export).
+
+### Fixed
+- `booked_delete_event_date` on an event that still has reservations now returns the actionable "retire it with `enabled=false` instead" message (via a typed exception) rather than a generic internal-error response.
+
 ## 1.2.0 - 2026-06-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## Unreleased
+## 1.2.0 - 2026-06-17
 
 ### Added
-- MCP integration: Booked now registers ~50 tools with the optional [craft-mcp](https://github.com/stimmtdigital/craft-mcp) plugin, exposing near-complete headless admin to AI assistants — services, employees, locations, schedules, blackout dates, service extras, availability, reservations, event dates, waitlist and reporting. Covers reads, create/update (soft-disable via `enabled` rather than hard delete), reschedule, quantity changes, refunds and analytics. The dependency is soft (`class_exists`-guarded) — Booked runs unchanged when craft-mcp is absent. Customer PII is redacted in bulk list output and booking capability tokens are never exposed. See [MCP.md](MCP.md).
+- MCP integration: Booked now registers ~50 tools with the optional [craft-mcp](https://github.com/stimmtdigital/craft-mcp) plugin, exposing near-complete headless admin to AI assistants — services, employees, locations, schedules, blackout dates, service extras, availability, reservations, event dates, waitlist and reporting. Covers reads, create/update (soft-disable via `enabled` rather than hard delete), reschedule, quantity changes, refunds and analytics. The dependency is soft (`class_exists`-guarded) — Booked runs unchanged when craft-mcp is absent. See [MCP.md](MCP.md).
+- MCP safety model: customer email/phone are redacted on every reservation/waitlist read (not just bulk lists); booking capability tokens and virtual-meeting URLs are never exposed; cancellations always run the refund/capacity-release flow (status cannot be force-set to `cancelled` via update); retired (disabled) services/events remain listable and re-enablable; inputs are validated (quantity ≥ 1, employee `serviceIds` must exist); and notification/refund side effects are rate-limited with a fixed-window, mutex-guarded limiter (separate budgets, charged only on success) since Booked's IP-based limiter does not apply over MCP. Authorization is delegated to the craft-mcp server (IP allowlist / dangerous-tool gating). All 50 tools verified end-to-end against the live MCP server.
 
 ## 1.1.1 - 2026-04-15
 

--- a/MCP.md
+++ b/MCP.md
@@ -43,25 +43,33 @@ for client-specific configuration.
 
 ## Security model
 
-**The MCP server is the trust boundary.** Booked's tools run in craft-mcp's
-console context, which has no logged-in user — so there is intentionally **no
-per-tool permission check or staff-scoping** (unlike the Control Panel, which
-gates the same operations behind `booked-manageBookings` etc.). Anyone who can
-reach the MCP server can read and mutate Booked data. Restrict access with
-craft-mcp's own settings:
+**The MCP server is the first trust boundary**, but Booked no longer relies on
+it alone for writes. craft-mcp's tools run in a console context with no
+logged-in user, so restrict access with its own settings first:
 
 - `enabled` — keep the server off in production unless you mean to expose it.
 - `enableDangerousTools` — gate the mutating tools (create/update/cancel/refund),
   all flagged `#[McpToolMeta(dangerous: true)]`.
 - `allowedIps` — limit which hosts may connect.
 
-Booked adds defence-in-depth on top of that boundary:
+On top of that, Booked applies its own authorization and abuse controls:
 
+- **Writes are default-deny.** Every mutating tool runs behind a write-authorization
+  gate. It is refused unless an administrator enables **Settings → Security → Allow
+  MCP write operations** (`mcpWriteEnabled`, off by default). Read-only tools are
+  always available. In a web context an authenticated user must additionally hold
+  `booked-manageBookings`, mirroring the Control Panel.
+- **Refunds need a second opt-in.** `booked_refund_reservation` also requires
+  **Allow MCP refunds** (`mcpAllowRefunds`, off by default) and is idempotent —
+  it never refunds more than the outstanding (paid minus already-refunded) amount.
 - **No capability tokens are exposed.** Booking `confirmationToken` (the sole
   auth for the public cancel/reschedule endpoints) and `virtualMeetingUrl` are
   never serialised; tools return only a `hasVirtualMeeting` flag.
-- **PII is redacted in bulk.** `booked_list_reservations` / `booked_list_waitlist`
-  mask customer email/phone; single-record `get` returns full detail.
+- **PII is redacted by default.** `Presenter` masks customer email/phone unless a
+  caller explicitly opts out, so list, get, create and update responses all redact
+  customer contact details — a forgotten flag fails safe.
+- **Result sets are bounded.** Every list tool clamps its page size to a hard
+  ceiling (200) so a single call can't materialise an entire table.
 - **Notification throttle.** Tools that send real email/SMS (create/cancel
   bookings, waitlist add/notify) share a cache-backed cap (120/hour) so a
   runaway client can't spam customers; callers get an `error` once it trips.
@@ -191,8 +199,11 @@ exist.
 
 Write tools route through Booked's services (`BookingService`,
 `EventDateService`, `ScheduleAssignmentService`, `ServiceExtraService`,
-`WaitlistService`, …) and element layer, so all validation, slot-locking,
-notification and webhook side effects behave identically to the Control Panel.
+`WaitlistService`, …) and element layer, so their validation, slot-locking,
+notification and webhook side effects match the Control Panel. Authorization,
+however, is enforced separately (see the Security model above): unlike the CP's
+public cancel/reschedule endpoints, MCP write tools act on raw ids and are gated
+by the `mcpWriteEnabled`/`mcpAllowRefunds` settings rather than a per-booking token.
 Every tool response is passed through a JSON-safe presenter, so reports that
 embed Craft elements are collapsed to compact `{id, title}` stubs.
 

--- a/MCP.md
+++ b/MCP.md
@@ -1,0 +1,199 @@
+# MCP Tools
+
+Booked integrates with the [craft-mcp](https://github.com/stimmtdigital/craft-mcp)
+plugin to expose its booking data and operations to AI assistants (Claude
+Desktop, Claude Code, Cursor, …) over the [Model Context Protocol](https://modelcontextprotocol.io).
+
+The integration is **optional and zero-config**. Booked only *soft-depends* on
+craft-mcp: when the plugin is installed, Booked registers its tools on craft-mcp's
+`EVENT_REGISTER_TOOLS` event; when it is absent, Booked runs exactly as before.
+Registration is guarded by a `class_exists()` check, so there is nothing to turn
+on inside Booked itself.
+
+## Setup
+
+1. Install and enable craft-mcp:
+
+   ```bash
+   composer require stimmt/craft-mcp
+   php craft plugin/install mcp
+   ```
+
+2. Enable the MCP server in `config/mcp.php`:
+
+   ```php
+   <?php
+   return [
+       'enabled' => true,
+   ];
+   ```
+
+3. Generate a client config (Claude Code, Cursor, Claude Desktop, …):
+
+   ```bash
+   php craft mcp/install
+   ```
+
+Booked's tools are then advertised automatically under the `booked` source. See
+the [craft-mcp docs](https://github.com/stimmtdigital/craft-mcp/blob/master/docs/extending.md)
+for client-specific configuration.
+
+> craft-mcp requires PHP 8.3+. Booked itself supports PHP 8.2+; the higher floor
+> only applies when you opt into the MCP integration.
+
+## Tools
+
+All tools are registered under the `PLUGIN` category. Tools that mutate data are
+flagged **dangerous** via `#[McpToolMeta(dangerous: true)]`, so MCP clients can
+require confirmation before running them.
+
+Booked has **no hard delete** for services, locations, employees or schedules —
+retire them with the matching `update_*` tool and `enabled: false` (blackout
+dates use `set_blackout_date_active`). The one exception is
+`booked_delete_event_date`, which hard-deletes but refuses when reservations
+exist.
+
+### Catalog — `CatalogTools`
+
+| Tool | Description | Dangerous |
+| --- | --- | --- |
+| `booked_list_services` | List bookable services (id, title, duration, price, slot length). | |
+| `booked_get_service` | Get a single service by id. | |
+| `booked_create_service` | Create a new bookable service. | ⚠️ |
+| `booked_update_service` | Update a service; `enabled:false` retires it. | ⚠️ |
+| `booked_list_employees` | List employees, filterable by service/location. | |
+| `booked_get_employee` | Get a single employee by id. | |
+| `booked_create_employee` | Create an employee (links services/location/user/working hours). | ⚠️ |
+| `booked_update_employee` | Update an employee; `enabled:false` retires them. | ⚠️ |
+| `booked_list_locations` | List locations with address and timezone. | |
+| `booked_get_location` | Get a single location by id. | |
+| `booked_create_location` | Create a location. | ⚠️ |
+| `booked_update_location` | Update a location; `enabled:false` retires it. | ⚠️ |
+
+### Availability — `AvailabilityTools`
+
+| Tool | Description | Dangerous |
+| --- | --- | --- |
+| `booked_check_availability` | Available slots for a day (Y-m-d), filterable by service/employee/location. | |
+| `booked_next_available_date` | Next day with an open slot, searching forward from today. | |
+| `booked_availability_summary` | Open/closed summary across a date range. | |
+
+### Reservations — `ReservationTools`
+
+| Tool | Description | Dangerous |
+| --- | --- | --- |
+| `booked_list_reservations` | List reservations, filterable by status/service/employee/location/date range. | |
+| `booked_get_reservation` | Get a single reservation by id. | |
+| `booked_booking_stats` | Aggregate counts (total, confirmed, pending, today, this month). | |
+| `booked_create_booking` | Create a time-slot reservation (full availability validation + slot locking). | ⚠️ |
+| `booked_create_event_booking` | Reserve seats on an event date (capacity-checked). | ⚠️ |
+| `booked_update_reservation` | Edit details, reschedule (date/time/employee/location), or set status (confirmed/cancelled). | ⚠️ |
+| `booked_reduce_reservation_quantity` | Release spots/seats (partial refund under Commerce). | ⚠️ |
+| `booked_increase_reservation_quantity` | Add spots/seats (re-checks capacity). | ⚠️ |
+| `booked_cancel_reservation` | Cancel a reservation, freeing its slot/capacity. | ⚠️ |
+| `booked_refund_reservation` | Issue a full Commerce refund (Commerce only). | ⚠️ |
+
+### Event dates — `EventDateTools`
+
+| Tool | Description | Dangerous |
+| --- | --- | --- |
+| `booked_list_event_dates` | List event dates, optionally bounded by a date range. | |
+| `booked_get_event_date` | Get an event date by id, including remaining capacity. | |
+| `booked_create_event_date` | Create a one-time event date. | ⚠️ |
+| `booked_update_event_date` | Update an event date; `enabled:false` retires it. | ⚠️ |
+| `booked_delete_event_date` | Delete an event date (fails if it has reservations). | ⚠️ |
+
+### Schedules — `ScheduleTools`
+
+| Tool | Description | Dangerous |
+| --- | --- | --- |
+| `booked_list_schedules` | List availability schedules (weekly working-hours patterns). | |
+| `booked_get_schedule` | Get a schedule by id, including its working-hours map. | |
+| `booked_create_schedule` | Create a schedule (working hours keyed "1"(Mon)–"7"(Sun)). | ⚠️ |
+| `booked_update_schedule` | Update a schedule. | ⚠️ |
+| `booked_get_employee_schedules` | List the schedules assigned to an employee. | |
+| `booked_set_employee_schedules` | Replace an employee's assigned schedules (priority order). | ⚠️ |
+
+### Blackout dates — `BlackoutDateTools`
+
+| Tool | Description | Dangerous |
+| --- | --- | --- |
+| `booked_list_blackout_dates` | List blackout date ranges and their scope. | |
+| `booked_create_blackout_date` | Create a blackout range (optionally scoped to locations/employees). | ⚠️ |
+| `booked_set_blackout_date_active` | Activate/deactivate a blackout (the soft alternative to deleting). | ⚠️ |
+| `booked_check_date_blacked_out` | Check whether a date is blacked out (optionally per employee/location). | |
+
+### Service extras & links — `ServiceExtraTools`
+
+| Tool | Description | Dangerous |
+| --- | --- | --- |
+| `booked_list_service_extras` | List all bookable add-ons. | |
+| `booked_create_service_extra` | Create an add-on (price/duration/required). | ⚠️ |
+| `booked_get_service_extras` | List the extras attached to a service. | |
+| `booked_set_service_extras` | Replace the extras attached to a service. | ⚠️ |
+| `booked_get_service_locations` | List the locations a service can be booked at. | |
+| `booked_set_service_locations` | Replace a service's locations (empty = all). | ⚠️ |
+
+### Reports — `ReportTools` (read-only)
+
+| Tool | Description |
+| --- | --- |
+| `booked_revenue_report` | Revenue over a date range (optional previous-period comparison). |
+| `booked_bookings_by_service` | Counts/revenue grouped by service. |
+| `booked_bookings_by_employee` | Counts/revenue grouped by employee. |
+| `booked_bookings_by_location` | Counts/revenue grouped by location. |
+| `booked_cancellation_report` | Cancellation/no-show counts and rates. |
+| `booked_peak_hours_report` | Busiest hours (optionally days of week). |
+| `booked_utilization_report` | Capacity utilization (booked vs available). |
+| `booked_dashboard_summary` | High-level dashboard summary. |
+
+### Waitlist — `WaitlistTools`
+
+| Tool | Description | Dangerous |
+| --- | --- | --- |
+| `booked_list_waitlist` | List active waitlist entries for a service. | |
+| `booked_waitlist_stats` | Aggregate waitlist statistics. | |
+| `booked_add_to_waitlist` | Add a customer to a service waitlist. | ⚠️ |
+| `booked_add_to_event_waitlist` | Add a customer to an event-date waitlist. | ⚠️ |
+| `booked_cancel_waitlist_entry` | Remove a waitlist entry. | ⚠️ |
+| `booked_notify_waitlist_entry` | Manually send the "spot available" notification. | ⚠️ |
+
+Write tools route through Booked's services (`BookingService`,
+`EventDateService`, `ScheduleAssignmentService`, `ServiceExtraService`,
+`WaitlistService`, …) and element layer, so all validation, slot-locking,
+notification and webhook side effects behave identically to the Control Panel.
+Every tool response is passed through a JSON-safe presenter, so reports that
+embed Craft elements are collapsed to compact `{id, title}` stubs.
+
+## How it works
+
+The tool classes live in [`src/mcp/`](src/mcp):
+
+- Each public tool method carries `#[McpTool(name, description)]` (from the
+  `mcp/sdk` package) plus `#[McpToolMeta(category, dangerous)]` (from craft-mcp).
+  These attributes are read **reflectively** by craft-mcp — Booked never
+  instantiates them, which is why the package can stay an optional dependency.
+- Tool bodies are wrapped in `ToolResponseTrait::guard()`, which converts any
+  thrown exception into a structured `['error' => …]` payload instead of a
+  transport fault.
+- `src/mcp/support/Presenter.php` is the single place that decides which element
+  fields are serialised over the protocol.
+
+Registration is wired in `Booked::registerMcpTools()`:
+
+```php
+if (!class_exists(\stimmt\craft\Mcp\Mcp::class)) {
+    return;
+}
+
+Event::on(
+    \stimmt\craft\Mcp\Mcp::class,
+    \stimmt\craft\Mcp\Mcp::EVENT_REGISTER_TOOLS,
+    static function(\stimmt\craft\Mcp\events\RegisterToolsEvent $event): void {
+        $event->addTool(\anvildev\booked\mcp\CatalogTools::class, 'booked');
+        $event->addTool(\anvildev\booked\mcp\AvailabilityTools::class, 'booked');
+        $event->addTool(\anvildev\booked\mcp\ReservationTools::class, 'booked');
+        $event->addTool(\anvildev\booked\mcp\EventDateTools::class, 'booked');
+    }
+);
+```

--- a/MCP.md
+++ b/MCP.md
@@ -41,6 +41,37 @@ for client-specific configuration.
 > craft-mcp requires PHP 8.3+. Booked itself supports PHP 8.2+; the higher floor
 > only applies when you opt into the MCP integration.
 
+## Security model
+
+**The MCP server is the trust boundary.** Booked's tools run in craft-mcp's
+console context, which has no logged-in user — so there is intentionally **no
+per-tool permission check or staff-scoping** (unlike the Control Panel, which
+gates the same operations behind `booked-manageBookings` etc.). Anyone who can
+reach the MCP server can read and mutate Booked data. Restrict access with
+craft-mcp's own settings:
+
+- `enabled` — keep the server off in production unless you mean to expose it.
+- `enableDangerousTools` — gate the mutating tools (create/update/cancel/refund),
+  all flagged `#[McpToolMeta(dangerous: true)]`.
+- `allowedIps` — limit which hosts may connect.
+
+Booked adds defence-in-depth on top of that boundary:
+
+- **No capability tokens are exposed.** Booking `confirmationToken` (the sole
+  auth for the public cancel/reschedule endpoints) and `virtualMeetingUrl` are
+  never serialised; tools return only a `hasVirtualMeeting` flag.
+- **PII is redacted in bulk.** `booked_list_reservations` / `booked_list_waitlist`
+  mask customer email/phone; single-record `get` returns full detail.
+- **Notification throttle.** Tools that send real email/SMS (create/cancel
+  bookings, waitlist add/notify) share a cache-backed cap (120/hour) so a
+  runaway client can't spam customers; callers get an `error` once it trips.
+- **Errors are sanitised.** Only Booked's own typed exceptions return their
+  message; anything else (DB/driver/internal) returns a generic error, with
+  detail kept in the server logs.
+- **Account/user links aren't editable over MCP.** `create/update_employee`
+  cannot set an employee's Craft `userId` (that controls CP booking visibility);
+  manage user links in the Control Panel.
+
 ## Tools
 
 All tools are registered under the `PLUGIN` category. Tools that mutate data are

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ ddev php craft plugin/install booked
 - [Developer Guide](DEVELOPER_GUIDE.md) - API reference and extension guide
 - [Event System](EVENT_SYSTEM.md) - Comprehensive event system documentation with examples
 - [GraphQL API](GRAPHQL.md) - GraphQL schema and query examples
+- [MCP Tools](MCP.md) - Expose Booked to AI assistants via the craft-mcp plugin
 - [Console Commands](CONSOLE_COMMANDS.md) - CLI commands for reminders, cleanup, and diagnostics
 
 ## Support

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "anvildev/craft-booked",
     "description": "A comprehensive booking system for Craft CMS",
     "type": "craft-plugin",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "keywords": [
         "craft",
         "cms",

--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,9 @@
         "phpunit/phpunit": "^9.5",
         "mockery/mockery": "^1.5"
     },
+    "suggest": {
+        "stimmt/craft-mcp": "Exposes Booked's services, availability, reservations and event dates as MCP tools for AI assistants (^8.3)."
+    },
     "autoload": {
         "psr-4": {
             "anvildev\\booked\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "anvildev/craft-booked",
     "description": "A comprehensive booking system for Craft CMS",
     "type": "craft-plugin",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "keywords": [
         "craft",
         "cms",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,6 +14,13 @@ parameters:
         - ../../vendor/craftcms/cms/bootstrap/console.php
         - stubs/phpstan-bootstrap.php
     ignoreErrors:
+        # Optional stimmt/craft-mcp integration (see composer.json "suggest") — the package and
+        # its mcp/sdk attributes are not installed in this repo; src/mcp tools are only ever
+        # loaded by craft-mcp's registry when it is present (registration is class_exists-guarded).
+        - '#Attribute class Mcp\\Capability\\Attribute\\\w+ does not exist#'
+        - '#Attribute class stimmt\\craft\\Mcp\\attributes\\McpToolMeta does not exist#'
+        - '#on an unknown class stimmt\\craft\\Mcp\\#'
+        - '#has invalid type stimmt\\craft\\Mcp\\events\\RegisterToolsEvent#'
         # Common patterns for Craft CMS plugins
         - '#Cannot access offset .+ on mixed#'
         - '#Cannot cast mixed to#'

--- a/src/Booked.php
+++ b/src/Booked.php
@@ -98,7 +98,7 @@ class Booked extends Plugin
      */
     public const EDITION_PRO = 'pro';
 
-    public string $schemaVersion = '1.2.0';
+    public string $schemaVersion = '1.2.1';
     public bool $hasCpSection = true;
     public bool $hasCpSettings = true;
 

--- a/src/Booked.php
+++ b/src/Booked.php
@@ -134,6 +134,7 @@ class Booked extends Plugin
         $this->registerGraphQl();
         $this->registerFieldTypes();
         $this->registerWidgetTypes();
+        $this->registerMcpTools();
     }
 
     public static function displayName(): string
@@ -158,6 +159,37 @@ class Booked extends Plugin
 
         Event::on(View::class, View::EVENT_REGISTER_CP_TEMPLATE_ROOTS, $handler);
         Event::on(View::class, View::EVENT_REGISTER_SITE_TEMPLATE_ROOTS, $handler);
+    }
+
+    /**
+     * Register Booked's tools with the craft-mcp plugin, when it is installed.
+     *
+     * Booked only soft-depends on stimmt/craft-mcp: the integration is wired up
+     * by listening for its tool-registration event, so Booked runs unchanged
+     * when the MCP plugin is absent. Each tool class declares its tools via
+     * `#[McpTool]` attributes, which craft-mcp reads reflectively.
+     */
+    private function registerMcpTools(): void
+    {
+        if (!class_exists(\stimmt\craft\Mcp\Mcp::class)) {
+            return;
+        }
+
+        Event::on(
+            \stimmt\craft\Mcp\Mcp::class,
+            \stimmt\craft\Mcp\Mcp::EVENT_REGISTER_TOOLS,
+            static function(\stimmt\craft\Mcp\events\RegisterToolsEvent $event): void {
+                $event->addTool(\anvildev\booked\mcp\CatalogTools::class, 'booked');
+                $event->addTool(\anvildev\booked\mcp\AvailabilityTools::class, 'booked');
+                $event->addTool(\anvildev\booked\mcp\ReservationTools::class, 'booked');
+                $event->addTool(\anvildev\booked\mcp\EventDateTools::class, 'booked');
+                $event->addTool(\anvildev\booked\mcp\ScheduleTools::class, 'booked');
+                $event->addTool(\anvildev\booked\mcp\BlackoutDateTools::class, 'booked');
+                $event->addTool(\anvildev\booked\mcp\ServiceExtraTools::class, 'booked');
+                $event->addTool(\anvildev\booked\mcp\ReportTools::class, 'booked');
+                $event->addTool(\anvildev\booked\mcp\WaitlistTools::class, 'booked');
+            }
+        );
     }
 
     private function registerServices(): void

--- a/src/mcp/AvailabilityTools.php
+++ b/src/mcp/AvailabilityTools.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace anvildev\booked\mcp;
+
+use anvildev\booked\Booked;
+use Mcp\Capability\Attribute\McpTool;
+use stimmt\craft\Mcp\attributes\McpToolMeta;
+use stimmt\craft\Mcp\enums\ToolCategory;
+
+/**
+ * MCP tools that expose Booked's availability engine.
+ *
+ * These are read-only computations — they never create or mutate reservations,
+ * so they are safe for an AI assistant to call freely when helping a user find
+ * a time to book.
+ */
+class AvailabilityTools
+{
+    use ToolResponseTrait;
+
+    /**
+     * Return bookable time slots for a single day.
+     *
+     * @param string $date Day to check, formatted Y-m-d.
+     * @param int|null $serviceId Restrict slots to this service.
+     * @param int|null $employeeId Restrict slots to this employee.
+     * @param int|null $locationId Restrict slots to this location.
+     * @param int $quantity Requested capacity per slot.
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_check_availability',
+        description: 'Get available booking slots for a given day (Y-m-d), optionally filtered by service, '
+            . 'employee and location. Read-only; does not reserve anything.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function checkAvailability(
+        string $date,
+        ?int $serviceId = null,
+        ?int $employeeId = null,
+        ?int $locationId = null,
+        int $quantity = 1,
+    ): array {
+        return $this->guard(function() use ($date, $serviceId, $employeeId, $locationId, $quantity): array {
+            $slots = Booked::getInstance()->getAvailability()->getAvailableSlots(
+                $date,
+                $employeeId,
+                $locationId,
+                $serviceId,
+                max(1, $quantity),
+            );
+
+            return [
+                'date' => $date,
+                'count' => count($slots),
+                'slots' => $slots,
+            ];
+        });
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_next_available_date',
+        description: 'Find the next day (Y-m-d) that has at least one available slot, searching forward from today.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function nextAvailableDate(
+        ?int $serviceId = null,
+        ?int $employeeId = null,
+        ?int $locationId = null,
+        int $maxDaysToSearch = 90,
+    ): array {
+        return $this->guard(function() use ($serviceId, $employeeId, $locationId, $maxDaysToSearch): array {
+            $date = Booked::getInstance()->getAvailability()->getNextAvailableDate(
+                $serviceId,
+                $employeeId,
+                $locationId,
+                $maxDaysToSearch,
+            );
+
+            return ['nextAvailableDate' => $date];
+        });
+    }
+
+    /**
+     * Summarise availability across a date range (e.g. to power a calendar).
+     *
+     * @param string $startDate Range start, Y-m-d.
+     * @param string $endDate Range end, Y-m-d.
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_availability_summary',
+        description: 'Summarise availability across a date range (Y-m-d to Y-m-d), optionally filtered by '
+            . 'service, employee and location. Useful for rendering a month of open/closed days.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function availabilitySummary(
+        string $startDate,
+        string $endDate,
+        ?int $serviceId = null,
+        ?int $employeeId = null,
+        ?int $locationId = null,
+    ): array {
+        return $this->guard(function() use ($startDate, $endDate, $serviceId, $employeeId, $locationId): array {
+            $summary = Booked::getInstance()->getAvailability()->getAvailabilitySummary(
+                $startDate,
+                $endDate,
+                $serviceId,
+                $employeeId,
+                $locationId,
+            );
+
+            return ['summary' => $summary];
+        });
+    }
+}

--- a/src/mcp/BlackoutDateTools.php
+++ b/src/mcp/BlackoutDateTools.php
@@ -32,7 +32,7 @@ class BlackoutDateTools
     public function listBlackoutDates(int $limit = 100): array
     {
         return $this->guard(function() use ($limit): array {
-            $blackouts = BlackoutDate::find()->siteId('*')->status(null)->limit($limit)->all();
+            $blackouts = BlackoutDate::find()->siteId('*')->status(null)->limit($this->clampLimit($limit))->all();
 
             return [
                 'count' => count($blackouts),
@@ -63,7 +63,7 @@ class BlackoutDateTools
         ?array $locationIds = null,
         ?array $employeeIds = null,
     ): array {
-        return $this->guard(function() use ($title, $startDate, $endDate, $locationIds, $employeeIds): array {
+        return $this->guardWrite(function() use ($title, $startDate, $endDate, $locationIds, $employeeIds): array {
             $blackout = new BlackoutDate();
             $blackout->title = $title;
             $blackout->startDate = $startDate;
@@ -95,7 +95,7 @@ class BlackoutDateTools
     #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
     public function setBlackoutDateActive(int $id, bool $isActive): array
     {
-        return $this->guard(function() use ($id, $isActive): array {
+        return $this->guardWrite(function() use ($id, $isActive): array {
             $blackout = BlackoutDate::find()->siteId('*')->status(null)->id($id)->one();
             if (!$blackout instanceof BlackoutDate) {
                 return ['error' => "Blackout date #{$id} not found."];

--- a/src/mcp/BlackoutDateTools.php
+++ b/src/mcp/BlackoutDateTools.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace anvildev\booked\mcp;
+
+use anvildev\booked\Booked;
+use anvildev\booked\elements\BlackoutDate;
+use anvildev\booked\mcp\support\Presenter;
+use Craft;
+use Mcp\Capability\Attribute\McpTool;
+use stimmt\craft\Mcp\attributes\McpToolMeta;
+use stimmt\craft\Mcp\enums\ToolCategory;
+
+/**
+ * MCP tools for blackout dates — ranges during which bookings are blocked,
+ * optionally scoped to specific locations and/or employees.
+ *
+ * There is no hard delete: deactivate a blackout with
+ * {@see self::setBlackoutDateActive()} (isActive=false) to lift it.
+ */
+class BlackoutDateTools
+{
+    use ToolResponseTrait;
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_list_blackout_dates',
+        description: 'List Booked blackout dates (ranges when booking is blocked), with their location/employee scope.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function listBlackoutDates(int $limit = 100): array
+    {
+        return $this->guard(function() use ($limit): array {
+            $blackouts = BlackoutDate::find()->siteId('*')->status(null)->limit($limit)->all();
+
+            return [
+                'count' => count($blackouts),
+                'blackoutDates' => array_map(static fn(BlackoutDate $b) => Presenter::blackoutDate($b), $blackouts),
+            ];
+        });
+    }
+
+    /**
+     * Create a blackout date range.
+     *
+     * @param string $title Label for the blackout (required).
+     * @param string $startDate Range start, Y-m-d.
+     * @param string $endDate Range end, Y-m-d.
+     * @param int[]|null $locationIds Limit the blackout to these locations (empty/null = all).
+     * @param int[]|null $employeeIds Limit the blackout to these employees (empty/null = all).
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_create_blackout_date',
+        description: 'Create a Booked blackout date range, optionally scoped to specific locations and/or employees.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
+    public function createBlackoutDate(
+        string $title,
+        string $startDate,
+        string $endDate,
+        ?array $locationIds = null,
+        ?array $employeeIds = null,
+    ): array {
+        return $this->guard(function() use ($title, $startDate, $endDate, $locationIds, $employeeIds): array {
+            $blackout = new BlackoutDate();
+            $blackout->title = $title;
+            $blackout->startDate = $startDate;
+            $blackout->endDate = $endDate;
+            $blackout->locationIds = $locationIds ?? [];
+            $blackout->employeeIds = $employeeIds ?? [];
+            $blackout->isActive = true;
+
+            if (!Craft::$app->getElements()->saveElement($blackout)) {
+                return ['error' => 'Failed to create blackout date.', 'validationErrors' => $blackout->getErrors()];
+            }
+
+            return ['success' => true, 'blackoutDate' => Presenter::blackoutDate($blackout)];
+        });
+    }
+
+    /**
+     * Activate or deactivate a blackout date (the soft alternative to deleting).
+     *
+     * @param int $id Blackout date id.
+     * @param bool $isActive Whether the blackout should be in effect.
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_set_blackout_date_active',
+        description: 'Activate or deactivate a blackout date by id (isActive). Use this to lift a blackout '
+            . 'instead of deleting it.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
+    public function setBlackoutDateActive(int $id, bool $isActive): array
+    {
+        return $this->guard(function() use ($id, $isActive): array {
+            $blackout = BlackoutDate::find()->siteId('*')->status(null)->id($id)->one();
+            if (!$blackout instanceof BlackoutDate) {
+                return ['error' => "Blackout date #{$id} not found."];
+            }
+
+            $blackout->isActive = $isActive;
+            if (!Craft::$app->getElements()->saveElement($blackout)) {
+                return ['error' => 'Failed to update blackout date.', 'validationErrors' => $blackout->getErrors()];
+            }
+
+            return ['success' => true, 'blackoutDate' => Presenter::blackoutDate($blackout)];
+        });
+    }
+
+    /**
+     * Check whether a given day is blacked out, optionally for a specific
+     * employee/location.
+     *
+     * @param string $date Day to check, Y-m-d.
+     * @param int|null $employeeId Restrict the check to this employee.
+     * @param int|null $locationId Restrict the check to this location.
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_check_date_blacked_out',
+        description: 'Check whether a date (Y-m-d) is blacked out, optionally for a specific employee/location.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function checkDateBlackedOut(string $date, ?int $employeeId = null, ?int $locationId = null): array
+    {
+        return $this->guard(static fn(): array => [
+            'date' => $date,
+            'isBlackedOut' => Booked::getInstance()->getBlackoutDate()->isDateBlackedOut($date, $employeeId, $locationId),
+        ]);
+    }
+}

--- a/src/mcp/CatalogTools.php
+++ b/src/mcp/CatalogTools.php
@@ -1,0 +1,455 @@
+<?php
+
+namespace anvildev\booked\mcp;
+
+use anvildev\booked\elements\Employee;
+use anvildev\booked\elements\Location;
+use anvildev\booked\elements\Service;
+use anvildev\booked\mcp\support\Presenter;
+use Craft;
+use Mcp\Capability\Attribute\McpTool;
+use Mcp\Capability\Attribute\Schema;
+use stimmt\craft\Mcp\attributes\McpToolMeta;
+use stimmt\craft\Mcp\enums\ToolCategory;
+
+/**
+ * MCP tools for Booked's catalog: services, employees and locations.
+ *
+ * Services are localized, so queries use `->unique()` to collapse per-site
+ * duplicates; employees and locations are not localized, so we only widen the
+ * site scope. All reads run across every site (`->siteId('*')`) and include
+ * disabled elements (`->status(null)`) — an admin AI assistant should see the
+ * full catalog, not just what a front-end visitor would.
+ */
+class CatalogTools
+{
+    use ToolResponseTrait;
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_list_services',
+        description: 'List bookable services in Booked (id, title, duration, price, slot length). '
+            . 'Returns both enabled and disabled services across all sites.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function listServices(int $limit = 50, int $offset = 0): array
+    {
+        return $this->guard(function() use ($limit, $offset): array {
+            $services = Service::find()
+                ->siteId('*')
+                ->status(null)
+                ->unique()
+                ->limit($limit)
+                ->offset($offset)
+                ->all();
+
+            return [
+                'count' => count($services),
+                'services' => array_map(static fn(Service $s) => Presenter::service($s), $services),
+            ];
+        });
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_get_service',
+        description: 'Get the full definition of a single Booked service by id.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function getService(int $id): array
+    {
+        return $this->guard(function() use ($id): array {
+            $service = Service::find()->siteId('*')->status(null)->unique()->id($id)->one();
+            if (!$service instanceof Service) {
+                return ['error' => "Service #{$id} not found."];
+            }
+
+            return ['service' => Presenter::service($service)];
+        });
+    }
+
+    /**
+     * Create a new bookable service.
+     *
+     * @param string $title Display name of the service (required).
+     * @param int $duration Length of the service in $durationType units.
+     * @param string $durationType One of: minutes, hours, days.
+     * @param float|null $price Flat price, when pricingMode is "flat".
+     * @param int|null $timeSlotLength Slot granularity in minutes (defaults to the service duration).
+     * @param bool $enabled Whether the service is immediately bookable.
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_create_service',
+        description: 'Create a new bookable service in Booked. Returns the created service.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
+    public function createService(
+        string $title,
+        int $duration = 60,
+        string $durationType = 'minutes',
+        ?float $price = null,
+        ?int $timeSlotLength = null,
+        bool $enabled = true,
+    ): array {
+        return $this->guard(function() use ($title, $duration, $durationType, $price, $timeSlotLength, $enabled): array {
+            $service = new Service();
+            $service->title = $title;
+            $service->duration = $duration;
+            $service->durationType = $durationType;
+            $service->price = $price;
+            $service->timeSlotLength = $timeSlotLength;
+            $service->enabled = $enabled;
+
+            if (!Craft::$app->getElements()->saveElement($service)) {
+                return [
+                    'error' => 'Failed to create service.',
+                    'validationErrors' => $service->getErrors(),
+                ];
+            }
+
+            return [
+                'success' => true,
+                'service' => Presenter::service($service),
+            ];
+        });
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_list_employees',
+        description: 'List Booked employees (staff who deliver services), including which services and location each is tied to.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function listEmployees(?int $serviceId = null, ?int $locationId = null, int $limit = 50): array
+    {
+        return $this->guard(function() use ($serviceId, $locationId, $limit): array {
+            $query = Employee::find()->siteId('*')->status(null)->limit($limit);
+            if ($serviceId !== null) {
+                $query->serviceId($serviceId);
+            }
+            if ($locationId !== null) {
+                $query->locationId($locationId);
+            }
+            $employees = $query->all();
+
+            return [
+                'count' => count($employees),
+                'employees' => array_map(static fn(Employee $e) => Presenter::employee($e), $employees),
+            ];
+        });
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_list_locations',
+        description: 'List Booked locations (where services are delivered), with address and timezone.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function listLocations(int $limit = 50): array
+    {
+        return $this->guard(function() use ($limit): array {
+            $locations = Location::find()->siteId('*')->status(null)->limit($limit)->all();
+
+            return [
+                'count' => count($locations),
+                'locations' => array_map(static fn(Location $l) => Presenter::location($l), $locations),
+            ];
+        });
+    }
+
+    /**
+     * Update an existing service. Only provided (non-null) fields are changed;
+     * pass enabled=false to soft-disable a service instead of deleting it.
+     *
+     * @param string $durationType One of: minutes, hours, days.
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_update_service',
+        description: 'Update a Booked service by id. Only the fields you pass are changed. '
+            . 'Set enabled=false to retire a service (Booked has no hard delete for services).',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
+    public function updateService(
+        int $id,
+        ?string $title = null,
+        ?int $duration = null,
+        ?string $durationType = null,
+        ?float $price = null,
+        ?int $timeSlotLength = null,
+        ?bool $enabled = null,
+    ): array {
+        return $this->guard(function() use ($id, $title, $duration, $durationType, $price, $timeSlotLength, $enabled): array {
+            $service = Service::find()->siteId('*')->status(null)->unique()->id($id)->one();
+            if (!$service instanceof Service) {
+                return ['error' => "Service #{$id} not found."];
+            }
+
+            if ($title !== null) {
+                $service->title = $title;
+            }
+            if ($duration !== null) {
+                $service->duration = $duration;
+            }
+            if ($durationType !== null) {
+                $service->durationType = $durationType;
+            }
+            if ($price !== null) {
+                $service->price = $price;
+            }
+            if ($timeSlotLength !== null) {
+                $service->timeSlotLength = $timeSlotLength;
+            }
+            if ($enabled !== null) {
+                $service->enabled = $enabled;
+            }
+
+            if (!Craft::$app->getElements()->saveElement($service)) {
+                return ['error' => 'Failed to update service.', 'validationErrors' => $service->getErrors()];
+            }
+
+            return ['success' => true, 'service' => Presenter::service($service)];
+        });
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_get_location',
+        description: 'Get a single Booked location by id.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function getLocation(int $id): array
+    {
+        return $this->guard(function() use ($id): array {
+            $location = Location::find()->siteId('*')->status(null)->id($id)->one();
+            if (!$location instanceof Location) {
+                return ['error' => "Location #{$id} not found."];
+            }
+
+            return ['location' => Presenter::location($location)];
+        });
+    }
+
+    /**
+     * Create a new location.
+     *
+     * @param string $title Display name of the location (required).
+     * @param string|null $timezone IANA timezone (e.g. Europe/Zurich); defaults to the system timezone.
+     * @param string|null $addressLine1 Street address.
+     * @param string|null $locality City / town.
+     * @param string|null $administrativeArea State / region.
+     * @param string|null $postalCode Postal / ZIP code.
+     * @param string|null $countryCode Two-letter ISO country code.
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_create_location',
+        description: 'Create a new Booked location. Returns the created location.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
+    public function createLocation(
+        string $title,
+        ?string $timezone = null,
+        ?string $addressLine1 = null,
+        ?string $locality = null,
+        ?string $administrativeArea = null,
+        ?string $postalCode = null,
+        ?string $countryCode = null,
+    ): array {
+        return $this->guard(function() use ($title, $timezone, $addressLine1, $locality, $administrativeArea, $postalCode, $countryCode): array {
+            $location = new Location();
+            $location->title = $title;
+            $location->timezone = $timezone;
+            $location->addressLine1 = $addressLine1;
+            $location->locality = $locality;
+            $location->administrativeArea = $administrativeArea;
+            $location->postalCode = $postalCode;
+            $location->countryCode = $countryCode;
+
+            if (!Craft::$app->getElements()->saveElement($location)) {
+                return ['error' => 'Failed to create location.', 'validationErrors' => $location->getErrors()];
+            }
+
+            return ['success' => true, 'location' => Presenter::location($location)];
+        });
+    }
+
+    /**
+     * Update a location. Only provided (non-null) fields change; pass
+     * enabled=false to retire it.
+     *
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_update_location',
+        description: 'Update a Booked location by id. Only the fields you pass are changed. '
+            . 'Set enabled=false to retire a location.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
+    public function updateLocation(
+        int $id,
+        ?string $title = null,
+        ?string $timezone = null,
+        ?string $addressLine1 = null,
+        ?string $locality = null,
+        ?string $administrativeArea = null,
+        ?string $postalCode = null,
+        ?string $countryCode = null,
+        ?bool $enabled = null,
+    ): array {
+        return $this->guard(function() use ($id, $title, $timezone, $addressLine1, $locality, $administrativeArea, $postalCode, $countryCode, $enabled): array {
+            $location = Location::find()->siteId('*')->status(null)->id($id)->one();
+            if (!$location instanceof Location) {
+                return ['error' => "Location #{$id} not found."];
+            }
+
+            foreach ([
+                'title' => $title,
+                'timezone' => $timezone,
+                'addressLine1' => $addressLine1,
+                'locality' => $locality,
+                'administrativeArea' => $administrativeArea,
+                'postalCode' => $postalCode,
+                'countryCode' => $countryCode,
+                'enabled' => $enabled,
+            ] as $field => $value) {
+                if ($value !== null) {
+                    $location->$field = $value;
+                }
+            }
+
+            if (!Craft::$app->getElements()->saveElement($location)) {
+                return ['error' => 'Failed to update location.', 'validationErrors' => $location->getErrors()];
+            }
+
+            return ['success' => true, 'location' => Presenter::location($location)];
+        });
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_get_employee',
+        description: 'Get a single Booked employee by id, including their service and location links.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function getEmployee(int $id): array
+    {
+        return $this->guard(function() use ($id): array {
+            $employee = Employee::find()->siteId('*')->status(null)->id($id)->one();
+            if (!$employee instanceof Employee) {
+                return ['error' => "Employee #{$id} not found."];
+            }
+
+            return ['employee' => Presenter::employee($employee)];
+        });
+    }
+
+    /**
+     * Create a new employee.
+     *
+     * @param string $title Employee display name (required).
+     * @param string|null $email Contact email.
+     * @param int|null $locationId Location this employee works at.
+     * @param int[]|null $serviceIds Ids of services this employee delivers.
+     * @param int|null $userId Linked Craft user id, for self-service.
+     * @param array<string, mixed>|null $workingHours Per-day hours keyed "1"(Mon)–"7"(Sun), each {enabled, start, end, breakStart?, breakEnd?}.
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_create_employee',
+        description: 'Create a new Booked employee (staff member who delivers services). '
+            . 'Optionally link services, a location, a Craft user, and inline working hours.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
+    public function createEmployee(
+        string $title,
+        ?string $email = null,
+        ?int $locationId = null,
+        ?array $serviceIds = null,
+        ?int $userId = null,
+        #[Schema(type: 'object')] ?array $workingHours = null,
+    ): array {
+        return $this->guard(function() use ($title, $email, $locationId, $serviceIds, $userId, $workingHours): array {
+            $employee = new Employee();
+            $employee->title = $title;
+            $employee->email = $email;
+            $employee->locationId = $locationId;
+            $employee->serviceIds = $serviceIds ?? [];
+            $employee->userId = $userId;
+            if ($workingHours !== null) {
+                $employee->workingHours = $workingHours;
+            }
+
+            if (!Craft::$app->getElements()->saveElement($employee)) {
+                return ['error' => 'Failed to create employee.', 'validationErrors' => $employee->getErrors()];
+            }
+
+            return ['success' => true, 'employee' => Presenter::employee($employee)];
+        });
+    }
+
+    /**
+     * Update an employee. Only provided (non-null) fields change; pass
+     * enabled=false to retire them.
+     *
+     * @param int[]|null $serviceIds Replacement set of service ids this employee delivers.
+     * @param array<string, mixed>|null $workingHours Per-day hours keyed "1"(Mon)–"7"(Sun).
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_update_employee',
+        description: 'Update a Booked employee by id. Only the fields you pass are changed. '
+            . 'Set enabled=false to retire them; serviceIds replaces the full set.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
+    public function updateEmployee(
+        int $id,
+        ?string $title = null,
+        ?string $email = null,
+        ?int $locationId = null,
+        ?array $serviceIds = null,
+        ?int $userId = null,
+        #[Schema(type: 'object')] ?array $workingHours = null,
+        ?bool $enabled = null,
+    ): array {
+        return $this->guard(function() use ($id, $title, $email, $locationId, $serviceIds, $userId, $workingHours, $enabled): array {
+            $employee = Employee::find()->siteId('*')->status(null)->id($id)->one();
+            if (!$employee instanceof Employee) {
+                return ['error' => "Employee #{$id} not found."];
+            }
+
+            foreach ([
+                'title' => $title,
+                'email' => $email,
+                'locationId' => $locationId,
+                'serviceIds' => $serviceIds,
+                'userId' => $userId,
+                'workingHours' => $workingHours,
+                'enabled' => $enabled,
+            ] as $field => $value) {
+                if ($value !== null) {
+                    $employee->$field = $value;
+                }
+            }
+
+            if (!Craft::$app->getElements()->saveElement($employee)) {
+                return ['error' => 'Failed to update employee.', 'validationErrors' => $employee->getErrors()];
+            }
+
+            return ['success' => true, 'employee' => Presenter::employee($employee)];
+        });
+    }
+}

--- a/src/mcp/CatalogTools.php
+++ b/src/mcp/CatalogTools.php
@@ -26,6 +26,24 @@ class CatalogTools
     use ToolResponseTrait;
 
     /**
+     * Return the $serviceIds that don't match an existing service, so an
+     * employee can't be linked to bogus ids. Empty means all are valid.
+     *
+     * @param int[] $serviceIds
+     * @return int[]
+     */
+    private function unknownServiceIds(array $serviceIds): array
+    {
+        if ($serviceIds === []) {
+            return [];
+        }
+        $ids = array_map('intval', $serviceIds);
+        $existing = array_map('intval', Service::find()->siteId('*')->status(null)->id($ids)->ids());
+
+        return array_values(array_diff(array_unique($ids), $existing));
+    }
+
+    /**
      * @return array<string, mixed>
      */
     #[McpTool(
@@ -383,6 +401,10 @@ class CatalogTools
         #[Schema(type: 'object')] ?array $workingHours = null,
     ): array {
         return $this->guard(function() use ($title, $email, $locationId, $serviceIds, $workingHours): array {
+            if ($serviceIds !== null && ($unknown = $this->unknownServiceIds($serviceIds)) !== []) {
+                return ['error' => 'Unknown serviceIds: ' . implode(', ', $unknown) . '.'];
+            }
+
             $employee = new Employee();
             $employee->title = $title;
             $employee->email = $email;
@@ -425,6 +447,10 @@ class CatalogTools
         ?bool $enabled = null,
     ): array {
         return $this->guard(function() use ($id, $title, $email, $locationId, $serviceIds, $workingHours, $enabled): array {
+            if ($serviceIds !== null && ($unknown = $this->unknownServiceIds($serviceIds)) !== []) {
+                return ['error' => 'Unknown serviceIds: ' . implode(', ', $unknown) . '.'];
+            }
+
             $employee = Employee::find()->siteId('*')->status(null)->id($id)->one();
             if (!$employee instanceof Employee) {
                 return ['error' => "Employee #{$id} not found."];

--- a/src/mcp/CatalogTools.php
+++ b/src/mcp/CatalogTools.php
@@ -59,8 +59,8 @@ class CatalogTools
                 ->siteId('*')
                 ->status(null)
                 ->unique()
-                ->limit($limit)
-                ->offset($offset)
+                ->limit($this->clampLimit($limit))
+                ->offset($this->clampOffset($offset))
                 ->all();
 
             return [
@@ -114,7 +114,7 @@ class CatalogTools
         ?int $timeSlotLength = null,
         bool $enabled = true,
     ): array {
-        return $this->guard(function() use ($title, $duration, $durationType, $price, $timeSlotLength, $enabled): array {
+        return $this->guardWrite(function() use ($title, $duration, $durationType, $price, $timeSlotLength, $enabled): array {
             $service = new Service();
             $service->title = $title;
             $service->duration = $duration;
@@ -148,7 +148,7 @@ class CatalogTools
     public function listEmployees(?int $serviceId = null, ?int $locationId = null, int $limit = 50): array
     {
         return $this->guard(function() use ($serviceId, $locationId, $limit): array {
-            $query = Employee::find()->siteId('*')->status(null)->limit($limit);
+            $query = Employee::find()->siteId('*')->status(null)->limit($this->clampLimit($limit));
             if ($serviceId !== null) {
                 $query->serviceId($serviceId);
             }
@@ -175,7 +175,7 @@ class CatalogTools
     public function listLocations(int $limit = 50): array
     {
         return $this->guard(function() use ($limit): array {
-            $locations = Location::find()->siteId('*')->status(null)->limit($limit)->all();
+            $locations = Location::find()->siteId('*')->status(null)->limit($this->clampLimit($limit))->all();
 
             return [
                 'count' => count($locations),
@@ -206,7 +206,7 @@ class CatalogTools
         ?int $timeSlotLength = null,
         ?bool $enabled = null,
     ): array {
-        return $this->guard(function() use ($id, $title, $duration, $durationType, $price, $timeSlotLength, $enabled): array {
+        return $this->guardWrite(function() use ($id, $title, $duration, $durationType, $price, $timeSlotLength, $enabled): array {
             $service = Service::find()->siteId('*')->status(null)->unique()->id($id)->one();
             if (!$service instanceof Service) {
                 return ['error' => "Service #{$id} not found."];
@@ -285,7 +285,7 @@ class CatalogTools
         ?string $postalCode = null,
         ?string $countryCode = null,
     ): array {
-        return $this->guard(function() use ($title, $timezone, $addressLine1, $locality, $administrativeArea, $postalCode, $countryCode): array {
+        return $this->guardWrite(function() use ($title, $timezone, $addressLine1, $locality, $administrativeArea, $postalCode, $countryCode): array {
             $location = new Location();
             $location->title = $title;
             $location->timezone = $timezone;
@@ -326,7 +326,7 @@ class CatalogTools
         ?string $countryCode = null,
         ?bool $enabled = null,
     ): array {
-        return $this->guard(function() use ($id, $title, $timezone, $addressLine1, $locality, $administrativeArea, $postalCode, $countryCode, $enabled): array {
+        return $this->guardWrite(function() use ($id, $title, $timezone, $addressLine1, $locality, $administrativeArea, $postalCode, $countryCode, $enabled): array {
             $location = Location::find()->siteId('*')->status(null)->id($id)->one();
             if (!$location instanceof Location) {
                 return ['error' => "Location #{$id} not found."];
@@ -400,7 +400,7 @@ class CatalogTools
         ?array $serviceIds = null,
         #[Schema(type: 'object')] ?array $workingHours = null,
     ): array {
-        return $this->guard(function() use ($title, $email, $locationId, $serviceIds, $workingHours): array {
+        return $this->guardWrite(function() use ($title, $email, $locationId, $serviceIds, $workingHours): array {
             if ($serviceIds !== null && ($unknown = $this->unknownServiceIds($serviceIds)) !== []) {
                 return ['error' => 'Unknown serviceIds: ' . implode(', ', $unknown) . '.'];
             }
@@ -446,7 +446,7 @@ class CatalogTools
         #[Schema(type: 'object')] ?array $workingHours = null,
         ?bool $enabled = null,
     ): array {
-        return $this->guard(function() use ($id, $title, $email, $locationId, $serviceIds, $workingHours, $enabled): array {
+        return $this->guardWrite(function() use ($id, $title, $email, $locationId, $serviceIds, $workingHours, $enabled): array {
             if ($serviceIds !== null && ($unknown = $this->unknownServiceIds($serviceIds)) !== []) {
                 return ['error' => 'Unknown serviceIds: ' . implode(', ', $unknown) . '.'];
             }

--- a/src/mcp/CatalogTools.php
+++ b/src/mcp/CatalogTools.php
@@ -364,14 +364,15 @@ class CatalogTools
      * @param string|null $email Contact email.
      * @param int|null $locationId Location this employee works at.
      * @param int[]|null $serviceIds Ids of services this employee delivers.
-     * @param int|null $userId Linked Craft user id, for self-service.
      * @param array<string, mixed>|null $workingHours Per-day hours keyed "1"(Mon)–"7"(Sun), each {enabled, start, end, breakStart?, breakEnd?}.
      * @return array<string, mixed>
      */
     #[McpTool(
         name: 'booked_create_employee',
         description: 'Create a new Booked employee (staff member who delivers services). '
-            . 'Optionally link services, a location, a Craft user, and inline working hours.',
+            . 'Optionally link services, a location, and inline working hours. '
+            . 'Linking to a Craft user account is intentionally not supported here (it controls '
+            . 'Control-Panel booking visibility) — do that in the CP.',
     )]
     #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
     public function createEmployee(
@@ -379,16 +380,14 @@ class CatalogTools
         ?string $email = null,
         ?int $locationId = null,
         ?array $serviceIds = null,
-        ?int $userId = null,
         #[Schema(type: 'object')] ?array $workingHours = null,
     ): array {
-        return $this->guard(function() use ($title, $email, $locationId, $serviceIds, $userId, $workingHours): array {
+        return $this->guard(function() use ($title, $email, $locationId, $serviceIds, $workingHours): array {
             $employee = new Employee();
             $employee->title = $title;
             $employee->email = $email;
             $employee->locationId = $locationId;
             $employee->serviceIds = $serviceIds ?? [];
-            $employee->userId = $userId;
             if ($workingHours !== null) {
                 $employee->workingHours = $workingHours;
             }
@@ -412,7 +411,8 @@ class CatalogTools
     #[McpTool(
         name: 'booked_update_employee',
         description: 'Update a Booked employee by id. Only the fields you pass are changed. '
-            . 'Set enabled=false to retire them; serviceIds replaces the full set.',
+            . 'Set enabled=false to retire them; serviceIds replaces the full set. '
+            . 'The Craft user link is intentionally not editable here (it controls CP booking visibility).',
     )]
     #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
     public function updateEmployee(
@@ -421,11 +421,10 @@ class CatalogTools
         ?string $email = null,
         ?int $locationId = null,
         ?array $serviceIds = null,
-        ?int $userId = null,
         #[Schema(type: 'object')] ?array $workingHours = null,
         ?bool $enabled = null,
     ): array {
-        return $this->guard(function() use ($id, $title, $email, $locationId, $serviceIds, $userId, $workingHours, $enabled): array {
+        return $this->guard(function() use ($id, $title, $email, $locationId, $serviceIds, $workingHours, $enabled): array {
             $employee = Employee::find()->siteId('*')->status(null)->id($id)->one();
             if (!$employee instanceof Employee) {
                 return ['error' => "Employee #{$id} not found."];
@@ -436,7 +435,6 @@ class CatalogTools
                 'email' => $email,
                 'locationId' => $locationId,
                 'serviceIds' => $serviceIds,
-                'userId' => $userId,
                 'workingHours' => $workingHours,
                 'enabled' => $enabled,
             ] as $field => $value) {

--- a/src/mcp/EventDateTools.php
+++ b/src/mcp/EventDateTools.php
@@ -32,11 +32,18 @@ class EventDateTools
             . 'optionally bounded by a date range.',
     )]
     #[McpToolMeta(category: ToolCategory::PLUGIN)]
-    public function listEventDates(?string $fromDate = null, ?string $toDate = null): array
+    public function listEventDates(?string $fromDate = null, ?string $toDate = null, int $limit = 50, int $offset = 0): array
     {
-        return $this->guard(function() use ($fromDate, $toDate): array {
+        return $this->guard(function() use ($fromDate, $toDate, $limit, $offset): array {
             // enabledOnly: false — admin listing includes retired events, like the other catalog tools.
-            $events = Booked::getInstance()->getEventDate()->getEventDates($fromDate, $toDate, '*', enabledOnly: false);
+            $events = Booked::getInstance()->getEventDate()->getEventDates(
+                $fromDate,
+                $toDate,
+                '*',
+                enabledOnly: false,
+                limit: $this->clampLimit($limit),
+                offset: $this->clampOffset($offset),
+            );
 
             return [
                 'count' => count($events),
@@ -103,7 +110,7 @@ class EventDateTools
         ?string $description = null,
         bool $enabled = true,
     ): array {
-        return $this->guard(function() use (
+        return $this->guardWrite(function() use (
             $title,
             $eventDate,
             $startTime,
@@ -158,7 +165,7 @@ class EventDateTools
         ?string $description = null,
         ?bool $enabled = null,
     ): array {
-        return $this->guard(function() use ($id, $title, $eventDate, $startTime, $endTime, $capacity, $locationId, $price, $description, $enabled): array {
+        return $this->guardWrite(function() use ($id, $title, $eventDate, $startTime, $endTime, $capacity, $locationId, $price, $description, $enabled): array {
             $data = array_filter([
                 'title' => $title,
                 'eventDate' => $eventDate,
@@ -196,7 +203,7 @@ class EventDateTools
     #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
     public function deleteEventDate(int $id): array
     {
-        return $this->guard(static fn(): array => [
+        return $this->guardWrite(static fn(): array => [
             'success' => Booked::getInstance()->getEventDate()->deleteEventDate($id, includeDisabled: true),
             'id' => $id,
         ]);

--- a/src/mcp/EventDateTools.php
+++ b/src/mcp/EventDateTools.php
@@ -35,7 +35,8 @@ class EventDateTools
     public function listEventDates(?string $fromDate = null, ?string $toDate = null): array
     {
         return $this->guard(function() use ($fromDate, $toDate): array {
-            $events = Booked::getInstance()->getEventDate()->getEventDates($fromDate, $toDate, '*');
+            // enabledOnly: false — admin listing includes retired events, like the other catalog tools.
+            $events = Booked::getInstance()->getEventDate()->getEventDates($fromDate, $toDate, '*', enabledOnly: false);
 
             return [
                 'count' => count($events),
@@ -55,16 +56,19 @@ class EventDateTools
     public function getEventDate(int $id): array
     {
         return $this->guard(function() use ($id): array {
-            $service = Booked::getInstance()->getEventDate();
-            $event = $service->getEventDateById($id);
+            $event = Booked::getInstance()->getEventDate()->getEventDateById($id, includeDisabled: true);
             if (!$event instanceof EventDate) {
                 return ['error' => "Event date #{$id} not found."];
             }
 
+            // Read off the loaded element: getRemainingCapacity() reuses this
+            // memoised count, so it's one count query rather than three.
+            $bookedCount = $event->getBookedCountCached();
+
             return [
                 'eventDate' => Presenter::eventDate($event),
-                'remainingCapacity' => $service->getRemainingCapacity($id),
-                'bookedCount' => $service->getBookedCount($id),
+                'remainingCapacity' => $event->getRemainingCapacity(),
+                'bookedCount' => $bookedCount,
             ];
         });
     }
@@ -171,7 +175,7 @@ class EventDateTools
                 return ['error' => 'Provide at least one field to update.'];
             }
 
-            $event = Booked::getInstance()->getEventDate()->updateEventDate($id, $data);
+            $event = Booked::getInstance()->getEventDate()->updateEventDate($id, $data, includeDisabled: true);
 
             return ['success' => true, 'eventDate' => Presenter::eventDate($event)];
         });
@@ -193,7 +197,7 @@ class EventDateTools
     public function deleteEventDate(int $id): array
     {
         return $this->guard(static fn(): array => [
-            'success' => Booked::getInstance()->getEventDate()->deleteEventDate($id),
+            'success' => Booked::getInstance()->getEventDate()->deleteEventDate($id, includeDisabled: true),
             'id' => $id,
         ]);
     }

--- a/src/mcp/EventDateTools.php
+++ b/src/mcp/EventDateTools.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace anvildev\booked\mcp;
+
+use anvildev\booked\Booked;
+use anvildev\booked\elements\EventDate;
+use anvildev\booked\mcp\support\Presenter;
+use Mcp\Capability\Attribute\McpTool;
+use stimmt\craft\Mcp\attributes\McpToolMeta;
+use stimmt\craft\Mcp\enums\ToolCategory;
+
+/**
+ * MCP tools for Booked's one-time events (event dates).
+ *
+ * Creation runs through {@see \anvildev\booked\services\EventDateService} so
+ * the element is validated and saved the same way the Control Panel does it.
+ */
+class EventDateTools
+{
+    use ToolResponseTrait;
+
+    /**
+     * List event dates, optionally bounded by a date range.
+     *
+     * @param string|null $fromDate Only events on/after this date (Y-m-d).
+     * @param string|null $toDate Only events on/before this date (Y-m-d).
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_list_event_dates',
+        description: 'List Booked event dates (one-time bookable events) with their capacity and pricing, '
+            . 'optionally bounded by a date range.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function listEventDates(?string $fromDate = null, ?string $toDate = null): array
+    {
+        return $this->guard(function() use ($fromDate, $toDate): array {
+            $events = Booked::getInstance()->getEventDate()->getEventDates($fromDate, $toDate, '*');
+
+            return [
+                'count' => count($events),
+                'eventDates' => array_map(static fn(EventDate $e) => Presenter::eventDate($e), $events),
+            ];
+        });
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_get_event_date',
+        description: 'Get a single Booked event date by id, including remaining capacity.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function getEventDate(int $id): array
+    {
+        return $this->guard(function() use ($id): array {
+            $service = Booked::getInstance()->getEventDate();
+            $event = $service->getEventDateById($id);
+            if (!$event instanceof EventDate) {
+                return ['error' => "Event date #{$id} not found."];
+            }
+
+            return [
+                'eventDate' => Presenter::eventDate($event),
+                'remainingCapacity' => $service->getRemainingCapacity($id),
+                'bookedCount' => $service->getBookedCount($id),
+            ];
+        });
+    }
+
+    /**
+     * Create a one-time event date.
+     *
+     * @param string $title Event name.
+     * @param string $eventDate Day of the event, Y-m-d.
+     * @param string $startTime Start time, HH:MM (24h).
+     * @param string $endTime End time, HH:MM (24h).
+     * @param int|null $capacity Maximum number of seats (null = unlimited).
+     * @param int|null $locationId Location the event is held at.
+     * @param float|null $price Price per seat.
+     * @param string|null $description Free-text description.
+     * @param bool $enabled Whether the event is immediately bookable.
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_create_event_date',
+        description: 'Create a one-time Booked event date. Returns the created event.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
+    public function createEventDate(
+        string $title,
+        string $eventDate,
+        string $startTime,
+        string $endTime,
+        ?int $capacity = null,
+        ?int $locationId = null,
+        ?float $price = null,
+        ?string $description = null,
+        bool $enabled = true,
+    ): array {
+        return $this->guard(function() use (
+            $title,
+            $eventDate,
+            $startTime,
+            $endTime,
+            $capacity,
+            $locationId,
+            $price,
+            $description,
+            $enabled,
+        ): array {
+            $event = Booked::getInstance()->getEventDate()->createEventDate([
+                'title' => $title,
+                'eventDate' => $eventDate,
+                'startTime' => $startTime,
+                'endTime' => $endTime,
+                'capacity' => $capacity,
+                'locationId' => $locationId,
+                'price' => $price,
+                'description' => $description,
+                'enabled' => $enabled,
+            ]);
+
+            return [
+                'success' => true,
+                'eventDate' => Presenter::eventDate($event),
+            ];
+        });
+    }
+
+    /**
+     * Update an event date. Only provided (non-null) fields change; pass
+     * enabled=false to hide it from booking.
+     *
+     * @param int $id Event date to update.
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_update_event_date',
+        description: 'Update a Booked event date by id. Only the fields you pass are changed. '
+            . 'Set enabled=false to retire it.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
+    public function updateEventDate(
+        int $id,
+        ?string $title = null,
+        ?string $eventDate = null,
+        ?string $startTime = null,
+        ?string $endTime = null,
+        ?int $capacity = null,
+        ?int $locationId = null,
+        ?float $price = null,
+        ?string $description = null,
+        ?bool $enabled = null,
+    ): array {
+        return $this->guard(function() use ($id, $title, $eventDate, $startTime, $endTime, $capacity, $locationId, $price, $description, $enabled): array {
+            $data = array_filter([
+                'title' => $title,
+                'eventDate' => $eventDate,
+                'startTime' => $startTime,
+                'endTime' => $endTime,
+                'capacity' => $capacity,
+                'locationId' => $locationId,
+                'price' => $price,
+                'description' => $description,
+                'enabled' => $enabled,
+            ], static fn($v) => $v !== null);
+
+            if ($data === []) {
+                return ['error' => 'Provide at least one field to update.'];
+            }
+
+            $event = Booked::getInstance()->getEventDate()->updateEventDate($id, $data);
+
+            return ['success' => true, 'eventDate' => Presenter::eventDate($event)];
+        });
+    }
+
+    /**
+     * Delete an event date. Refused (with an error) if any reservations exist
+     * for it — retire it with update enabled=false instead.
+     *
+     * @param int $id Event date to delete.
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_delete_event_date',
+        description: 'Delete a Booked event date by id. Fails if it has any reservations; in that case set '
+            . 'enabled=false via booked_update_event_date instead.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
+    public function deleteEventDate(int $id): array
+    {
+        return $this->guard(static fn(): array => [
+            'success' => Booked::getInstance()->getEventDate()->deleteEventDate($id),
+            'id' => $id,
+        ]);
+    }
+}

--- a/src/mcp/ReportTools.php
+++ b/src/mcp/ReportTools.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace anvildev\booked\mcp;
+
+use anvildev\booked\Booked;
+use Mcp\Capability\Attribute\McpTool;
+use stimmt\craft\Mcp\attributes\McpToolMeta;
+use stimmt\craft\Mcp\enums\ToolCategory;
+
+/**
+ * MCP tools exposing Booked's reporting/analytics surface.
+ *
+ * All read-only. Date arguments are Y-m-d; most reports default to a sensible
+ * recent window when dates are omitted. Monetary figures use the store currency
+ * (see the `currency` field in revenue results).
+ */
+class ReportTools
+{
+    use ToolResponseTrait;
+
+    /**
+     * @param string|null $startDate Window start, Y-m-d.
+     * @param string|null $endDate Window end, Y-m-d.
+     * @param bool $includePreviousPeriod Also return the preceding period for comparison.
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_revenue_report',
+        description: 'Revenue totals over a date range (optionally with the previous period for comparison).',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function revenueReport(?string $startDate = null, ?string $endDate = null, bool $includePreviousPeriod = false): array
+    {
+        return $this->guard(static function() use ($startDate, $endDate, $includePreviousPeriod): array {
+            $reports = Booked::getInstance()->getReports();
+
+            return [
+                'currency' => $reports->getCurrency(),
+                'revenue' => $reports->getRevenueData($startDate, $endDate, $includePreviousPeriod),
+            ];
+        });
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_bookings_by_service',
+        description: 'Booking counts and revenue grouped by service over a date range.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function bookingsByService(?string $startDate = null, ?string $endDate = null): array
+    {
+        return $this->guard(static fn(): array => [
+            'byService' => Booked::getInstance()->getReports()->getByServiceData($startDate, $endDate),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_bookings_by_employee',
+        description: 'Booking counts and revenue grouped by employee over a date range.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function bookingsByEmployee(?string $startDate = null, ?string $endDate = null): array
+    {
+        return $this->guard(static fn(): array => [
+            'byEmployee' => Booked::getInstance()->getReports()->getByEmployeeData($startDate, $endDate),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_bookings_by_location',
+        description: 'Booking counts and revenue grouped by location over a date range.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function bookingsByLocation(?string $startDate = null, ?string $endDate = null): array
+    {
+        return $this->guard(static fn(): array => [
+            'byLocation' => Booked::getInstance()->getReports()->getByLocationData($startDate, $endDate),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_cancellation_report',
+        description: 'Cancellation and no-show counts/rates over a date range.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function cancellationReport(?string $startDate = null, ?string $endDate = null): array
+    {
+        return $this->guard(static fn(): array => [
+            'cancellations' => Booked::getInstance()->getReports()->getCancellationData($startDate, $endDate),
+        ]);
+    }
+
+    /**
+     * @param bool $includeDayOfWeek Break results down by day of week as well as hour.
+     * @param int|null $serviceId Restrict to a single service.
+     * @param int|null $employeeId Restrict to a single employee.
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_peak_hours_report',
+        description: 'Busiest hours (and optionally days of week) over a date range, optionally filtered by service/employee.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function peakHoursReport(
+        ?string $startDate = null,
+        ?string $endDate = null,
+        bool $includeDayOfWeek = false,
+        ?int $serviceId = null,
+        ?int $employeeId = null,
+    ): array {
+        return $this->guard(static fn(): array => [
+            'peakHours' => Booked::getInstance()->getReports()->getPeakHoursData($startDate, $endDate, $includeDayOfWeek, $serviceId, $employeeId),
+        ]);
+    }
+
+    /**
+     * @param string $startDate Window start, Y-m-d (required).
+     * @param string $endDate Window end, Y-m-d (required).
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_utilization_report',
+        description: 'Capacity utilization (booked vs available) over a date range, optionally filtered by service/employee/location.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function utilizationReport(
+        string $startDate,
+        string $endDate,
+        ?int $serviceId = null,
+        ?int $employeeId = null,
+        ?int $locationId = null,
+    ): array {
+        return $this->guard(static fn(): array => [
+            'utilization' => Booked::getInstance()->getReports()->getUtilizationData($startDate, $endDate, $serviceId, $employeeId, $locationId),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_dashboard_summary',
+        description: 'High-level dashboard summary (upcoming bookings, today/this-week counts, recent activity).',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function dashboardSummary(): array
+    {
+        return $this->guard(static fn(): array => [
+            'dashboard' => Booked::getInstance()->getDashboard()->getDashboardData(null),
+        ]);
+    }
+}

--- a/src/mcp/ReportTools.php
+++ b/src/mcp/ReportTools.php
@@ -33,10 +33,19 @@ class ReportTools
     {
         return $this->guard(static function() use ($startDate, $endDate, $includePreviousPeriod): array {
             $reports = Booked::getInstance()->getReports();
+            $revenue = $reports->getRevenueData($startDate, $endDate, $includePreviousPeriod);
+
+            // getRevenueData carries the underlying reservation models for the CP
+            // view/CSV export; over MCP they serialise to opaque {_class} stubs and
+            // would leak per-customer detail into a totals report, so summarise as a count.
+            if (is_array($revenue['reservations'] ?? null)) {
+                $revenue['reservationCount'] = count($revenue['reservations']);
+                unset($revenue['reservations']);
+            }
 
             return [
                 'currency' => $reports->getCurrency(),
-                'revenue' => $reports->getRevenueData($startDate, $endDate, $includePreviousPeriod),
+                'revenue' => $revenue,
             ];
         });
     }

--- a/src/mcp/ReservationTools.php
+++ b/src/mcp/ReservationTools.php
@@ -73,9 +73,11 @@ class ReservationTools
             if ($fromDate !== null && $toDate !== null) {
                 $query->bookingDate(['and', ">= {$fromDate}", "<= {$toDate}"]);
             } elseif ($fromDate !== null) {
-                $query->bookingDate(">= {$fromDate}");
+                // Array form, not ">= {$fromDate}": ReservationModelQuery treats
+                // the string as a literal equality match and finds nothing.
+                $query->bookingDate(['>=', $fromDate]);
             } elseif ($toDate !== null) {
-                $query->bookingDate("<= {$toDate}");
+                $query->bookingDate(['<=', $toDate]);
             }
 
             $reservations = $query->all();
@@ -106,7 +108,9 @@ class ReservationTools
                 return ['error' => "Reservation #{$id} not found."];
             }
 
-            return ['reservation' => Presenter::reservation($reservation)];
+            // Redact here too — ids are enumerable, so an un-redacted get would
+            // bypass the bulk-list redaction one record at a time.
+            return ['reservation' => Presenter::reservation($reservation, redactPii: true)];
         });
     }
 
@@ -170,8 +174,11 @@ class ReservationTools
             $quantity,
             $userTimezone,
         ): array {
-            if (!$this->withinRateLimit('notify', 120)) {
-                return ['error' => 'Booked MCP notification rate limit reached (120/hour); pause before creating more bookings.'];
+            if ($quantity < 1) {
+                return ['error' => 'quantity must be at least 1.'];
+            }
+            if ($this->rateLimitReached()) {
+                return $this->rateLimitError('creating more bookings');
             }
 
             $reservation = Booked::getInstance()->getBooking()->createReservation([
@@ -183,10 +190,13 @@ class ReservationTools
                 'userPhone' => $userPhone,
                 'employeeId' => $employeeId,
                 'locationId' => $locationId,
-                'quantity' => max(1, $quantity),
+                'quantity' => $quantity,
                 'userTimezone' => $userTimezone,
                 'source' => 'mcp',
             ]);
+
+            // Record only after success, so failed attempts don't consume budget.
+            $this->recordRateLimitedCall();
 
             return [
                 'success' => true,
@@ -219,8 +229,11 @@ class ReservationTools
         int $quantity = 1,
     ): array {
         return $this->guard(function() use ($eventDateId, $userName, $userEmail, $userPhone, $quantity): array {
-            if (!$this->withinRateLimit('notify', 120)) {
-                return ['error' => 'Booked MCP notification rate limit reached (120/hour); pause before creating more bookings.'];
+            if ($quantity < 1) {
+                return ['error' => 'quantity must be at least 1.'];
+            }
+            if ($this->rateLimitReached()) {
+                return $this->rateLimitError('creating more bookings');
             }
 
             $reservation = Booked::getInstance()->getBooking()->createReservation([
@@ -228,9 +241,11 @@ class ReservationTools
                 'userName' => $userName,
                 'userEmail' => $userEmail,
                 'userPhone' => $userPhone,
-                'quantity' => max(1, $quantity),
+                'quantity' => $quantity,
                 'source' => 'mcp',
             ]);
+
+            $this->recordRateLimitedCall();
 
             return [
                 'success' => true,
@@ -253,11 +268,16 @@ class ReservationTools
     public function cancelReservation(int $id, string $reason = ''): array
     {
         return $this->guard(function() use ($id, $reason): array {
-            if (!$this->withinRateLimit('notify', 120)) {
-                return ['error' => 'Booked MCP notification rate limit reached (120/hour); pause before cancelling more bookings.'];
+            if ($this->rateLimitReached()) {
+                return $this->rateLimitError('cancelling more bookings');
             }
 
             $ok = Booked::getInstance()->getBooking()->cancelReservation($id, $reason);
+
+            // Only a real cancellation notifies; a no-op doesn't, so don't charge it.
+            if ($ok) {
+                $this->recordRateLimitedCall();
+            }
 
             return [
                 'success' => $ok,
@@ -277,7 +297,7 @@ class ReservationTools
      * @param string|null $startTime New start time, HH:MM (reschedule).
      * @param int|null $employeeId Reassign to this employee (reschedule).
      * @param int|null $locationId Reassign to this location (reschedule).
-     * @param string|null $status New status: confirmed or cancelled. (pending is reserved for Commerce; cancelling here does not run the refund/capacity-release flow — use booked_cancel_reservation for that.)
+     * @param string|null $status New status: confirmed. (pending is reserved for Commerce; to cancel, use booked_cancel_reservation — this tool rejects status=cancelled because flipping the field here skips the refund/capacity-release flow.)
      * @param string|null $userName Customer name.
      * @param string|null $userEmail Customer email.
      * @param string|null $userPhone Customer phone.
@@ -287,8 +307,8 @@ class ReservationTools
     #[McpTool(
         name: 'booked_update_reservation',
         description: 'Update a reservation: edit customer details, reschedule (date/time/employee/location), '
-            . 'or set status (confirmed or cancelled). Reschedules are availability-validated and slot-locked. '
-            . 'To cancel with refund/capacity release, prefer booked_cancel_reservation.',
+            . 'or set status to confirmed. Reschedules are availability-validated and slot-locked. '
+            . 'To cancel, use booked_cancel_reservation (status=cancelled is rejected here, as it would skip refund/capacity release).',
     )]
     #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
     public function updateReservation(
@@ -304,6 +324,12 @@ class ReservationTools
         ?string $notes = null,
     ): array {
         return $this->guard(function() use ($id, $bookingDate, $startTime, $employeeId, $locationId, $status, $userName, $userEmail, $userPhone, $notes): array {
+            // Flipping status to cancelled here skips the refund, capacity
+            // release and waitlist notify that executeCancellation() runs.
+            if ($status === 'cancelled') {
+                return ['error' => 'Use booked_cancel_reservation to cancel; it runs the refund and capacity-release flow that updating the status directly would skip.'];
+            }
+
             $data = array_filter([
                 'bookingDate' => $bookingDate,
                 'startTime' => $startTime,
@@ -320,7 +346,21 @@ class ReservationTools
                 return ['error' => 'Provide at least one field to update.'];
             }
 
+            // A status change or reschedule notifies; a bare detail edit doesn't.
+            $willNotify = $status !== null
+                || $bookingDate !== null
+                || $startTime !== null
+                || $employeeId !== null
+                || $locationId !== null;
+            if ($willNotify && $this->rateLimitReached()) {
+                return $this->rateLimitError('updating more reservations');
+            }
+
             $reservation = Booked::getInstance()->getBooking()->updateReservation($id, $data);
+
+            if ($willNotify) {
+                $this->recordRateLimitedCall();
+            }
 
             return ['success' => true, 'reservation' => Presenter::reservation($reservation)];
         });
@@ -340,10 +380,19 @@ class ReservationTools
     #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
     public function reduceReservationQuantity(int $id, int $reduceBy, string $reason = ''): array
     {
-        return $this->guard(static fn(): array => [
-            'success' => Booked::getInstance()->getBooking()->reduceQuantity($id, $reduceBy, $reason),
-            'id' => $id,
-        ]);
+        return $this->guard(function() use ($id, $reduceBy, $reason): array {
+            // Notifies the waitlist and emails the customer (and refunds under Commerce).
+            if ($this->rateLimitReached()) {
+                return $this->rateLimitError('changing more reservation quantities');
+            }
+
+            $ok = Booked::getInstance()->getBooking()->reduceQuantity($id, $reduceBy, $reason);
+            if ($ok) {
+                $this->recordRateLimitedCall();
+            }
+
+            return ['success' => $ok, 'id' => $id];
+        });
     }
 
     /**
@@ -358,10 +407,18 @@ class ReservationTools
     #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
     public function increaseReservationQuantity(int $id, int $increaseBy): array
     {
-        return $this->guard(static fn(): array => [
-            'success' => Booked::getInstance()->getBooking()->increaseQuantity($id, $increaseBy),
-            'id' => $id,
-        ]);
+        return $this->guard(function() use ($id, $increaseBy): array {
+            if ($this->rateLimitReached()) {
+                return $this->rateLimitError('changing more reservation quantities');
+            }
+
+            $ok = Booked::getInstance()->getBooking()->increaseQuantity($id, $increaseBy);
+            if ($ok) {
+                $this->recordRateLimitedCall();
+            }
+
+            return ['success' => $ok, 'id' => $id];
+        });
     }
 
     /**
@@ -390,8 +447,18 @@ class ReservationTools
                 return ['error' => "Reservation #{$id} not found."];
             }
 
+            // Own budget — a refund spree shouldn't lock out cancellations.
+            if ($this->rateLimitReached('refund')) {
+                return $this->rateLimitError('issuing more refunds');
+            }
+
+            $ok = $booked->getRefund()->processFullRefund($reservation);
+            if ($ok) {
+                $this->recordRateLimitedCall('refund');
+            }
+
             return [
-                'success' => $booked->getRefund()->processFullRefund($reservation),
+                'success' => $ok,
                 'id' => $id,
             ];
         });

--- a/src/mcp/ReservationTools.php
+++ b/src/mcp/ReservationTools.php
@@ -1,0 +1,387 @@
+<?php
+
+namespace anvildev\booked\mcp;
+
+use anvildev\booked\Booked;
+use anvildev\booked\contracts\ReservationInterface;
+use anvildev\booked\factories\ReservationFactory;
+use anvildev\booked\mcp\support\Presenter;
+
+use Mcp\Capability\Attribute\McpTool;
+use stimmt\craft\Mcp\attributes\McpToolMeta;
+use stimmt\craft\Mcp\enums\ToolCategory;
+
+/**
+ * MCP tools for reading and managing reservations.
+ *
+ * Reads go through the reservation query layer; writes go through
+ * {@see \anvildev\booked\services\BookingService}, so all of Booked's
+ * validation, slot-locking and notification side effects are preserved.
+ * The create/cancel tools are flagged dangerous because they commit (or undo)
+ * real bookings.
+ */
+class ReservationTools
+{
+    use ToolResponseTrait;
+
+    /**
+     * List reservations with optional filters.
+     *
+     * @param string|null $status One of: pending, confirmed, cancelled, no_show.
+     * @param int|null $serviceId Filter by service.
+     * @param int|null $employeeId Filter by employee.
+     * @param int|null $locationId Filter by location.
+     * @param string|null $fromDate Only reservations on/after this booking date (Y-m-d).
+     * @param string|null $toDate Only reservations on/before this booking date (Y-m-d).
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_list_reservations',
+        description: 'List reservations, optionally filtered by status, service, employee, location and '
+            . 'booking-date range. Returns customer and slot details for each.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function listReservations(
+        ?string $status = null,
+        ?int $serviceId = null,
+        ?int $employeeId = null,
+        ?int $locationId = null,
+        ?string $fromDate = null,
+        ?string $toDate = null,
+        int $limit = 50,
+        int $offset = 0,
+    ): array {
+        return $this->guard(function() use ($status, $serviceId, $employeeId, $locationId, $fromDate, $toDate, $limit, $offset): array {
+            $query = ReservationFactory::find()
+                ->siteId('*')
+                ->status(null)
+                ->limit($limit)
+                ->offset($offset);
+
+            if ($status !== null) {
+                $query->reservationStatus($status);
+            }
+            if ($serviceId !== null) {
+                $query->serviceId($serviceId);
+            }
+            if ($employeeId !== null) {
+                $query->employeeId($employeeId);
+            }
+            if ($locationId !== null) {
+                $query->locationId($locationId);
+            }
+            if ($fromDate !== null && $toDate !== null) {
+                $query->bookingDate(['and', ">= {$fromDate}", "<= {$toDate}"]);
+            } elseif ($fromDate !== null) {
+                $query->bookingDate(">= {$fromDate}");
+            } elseif ($toDate !== null) {
+                $query->bookingDate("<= {$toDate}");
+            }
+
+            $reservations = $query->all();
+
+            return [
+                'count' => count($reservations),
+                'reservations' => array_map(
+                    static fn(ReservationInterface $r) => Presenter::reservation($r, redactPii: true),
+                    $reservations,
+                ),
+            ];
+        });
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_get_reservation',
+        description: 'Get a single reservation by id, including customer, slot and status details.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function getReservation(int $id): array
+    {
+        return $this->guard(function() use ($id): array {
+            $reservation = Booked::getInstance()->getBooking()->getReservationById($id);
+            if (!$reservation instanceof ReservationInterface) {
+                return ['error' => "Reservation #{$id} not found."];
+            }
+
+            return ['reservation' => Presenter::reservation($reservation)];
+        });
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_booking_stats',
+        description: 'Get aggregate booking counts (total, confirmed, pending, today, this month).',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function bookingStats(): array
+    {
+        return $this->guard(static fn(): array => [
+            'stats' => Booked::getInstance()->getBooking()->getBookingStats(),
+        ]);
+    }
+
+    /**
+     * Create a reservation for a time-slot service.
+     *
+     * @param int $serviceId Service being booked.
+     * @param string $bookingDate Day of the booking, Y-m-d.
+     * @param string $startTime Slot start time, HH:MM (24h).
+     * @param string $userName Customer name.
+     * @param string $userEmail Customer email.
+     * @param string|null $userPhone Customer phone (optional).
+     * @param int|null $employeeId Specific employee, if the service requires one.
+     * @param int|null $locationId Specific location, if applicable.
+     * @param int $quantity Number of spots/seats to book.
+     * @param string|null $userTimezone IANA timezone of the customer (e.g. Europe/Zurich).
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_create_booking',
+        description: 'Create a reservation for a time-slot service. Runs full availability validation and '
+            . 'slot locking; returns the created reservation or a validation error.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
+    public function createBooking(
+        int $serviceId,
+        string $bookingDate,
+        string $startTime,
+        string $userName,
+        string $userEmail,
+        ?string $userPhone = null,
+        ?int $employeeId = null,
+        ?int $locationId = null,
+        int $quantity = 1,
+        ?string $userTimezone = null,
+    ): array {
+        return $this->guard(function() use (
+            $serviceId,
+            $bookingDate,
+            $startTime,
+            $userName,
+            $userEmail,
+            $userPhone,
+            $employeeId,
+            $locationId,
+            $quantity,
+            $userTimezone,
+        ): array {
+            $reservation = Booked::getInstance()->getBooking()->createReservation([
+                'serviceId' => $serviceId,
+                'bookingDate' => $bookingDate,
+                'startTime' => $startTime,
+                'userName' => $userName,
+                'userEmail' => $userEmail,
+                'userPhone' => $userPhone,
+                'employeeId' => $employeeId,
+                'locationId' => $locationId,
+                'quantity' => max(1, $quantity),
+                'userTimezone' => $userTimezone,
+                'source' => 'mcp',
+            ]);
+
+            return [
+                'success' => true,
+                'reservation' => Presenter::reservation($reservation),
+            ];
+        });
+    }
+
+    /**
+     * Book a spot on a one-time event date.
+     *
+     * @param int $eventDateId Event date to book.
+     * @param string $userName Customer name.
+     * @param string $userEmail Customer email.
+     * @param string|null $userPhone Customer phone (optional).
+     * @param int $quantity Number of seats to reserve.
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_create_event_booking',
+        description: 'Reserve one or more seats on a Booked event date. Validates remaining capacity; '
+            . 'returns the created reservation or an error.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
+    public function createEventBooking(
+        int $eventDateId,
+        string $userName,
+        string $userEmail,
+        ?string $userPhone = null,
+        int $quantity = 1,
+    ): array {
+        return $this->guard(function() use ($eventDateId, $userName, $userEmail, $userPhone, $quantity): array {
+            $reservation = Booked::getInstance()->getBooking()->createReservation([
+                'eventDateId' => $eventDateId,
+                'userName' => $userName,
+                'userEmail' => $userEmail,
+                'userPhone' => $userPhone,
+                'quantity' => max(1, $quantity),
+                'source' => 'mcp',
+            ]);
+
+            return [
+                'success' => true,
+                'reservation' => Presenter::reservation($reservation),
+            ];
+        });
+    }
+
+    /**
+     * @param int $id Reservation to cancel.
+     * @param string $reason Optional reason recorded against the cancellation.
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_cancel_reservation',
+        description: 'Cancel an existing reservation by id, freeing its slot/capacity. Returns whether the '
+            . 'cancellation succeeded.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
+    public function cancelReservation(int $id, string $reason = ''): array
+    {
+        return $this->guard(function() use ($id, $reason): array {
+            $ok = Booked::getInstance()->getBooking()->cancelReservation($id, $reason);
+
+            return [
+                'success' => $ok,
+                'id' => $id,
+            ];
+        });
+    }
+
+    /**
+     * Update an existing reservation: edit customer details, reschedule
+     * (date/time/employee/location), or change status. Only provided (non-null)
+     * fields change. Rescheduling re-runs availability validation and slot
+     * locking, exactly like the Control Panel.
+     *
+     * @param int $id Reservation to update.
+     * @param string|null $bookingDate New booking date, Y-m-d (reschedule).
+     * @param string|null $startTime New start time, HH:MM (reschedule).
+     * @param int|null $employeeId Reassign to this employee (reschedule).
+     * @param int|null $locationId Reassign to this location (reschedule).
+     * @param string|null $status New status: confirmed or cancelled. (pending is reserved for Commerce; cancelling here does not run the refund/capacity-release flow — use booked_cancel_reservation for that.)
+     * @param string|null $userName Customer name.
+     * @param string|null $userEmail Customer email.
+     * @param string|null $userPhone Customer phone.
+     * @param string|null $notes Internal notes.
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_update_reservation',
+        description: 'Update a reservation: edit customer details, reschedule (date/time/employee/location), '
+            . 'or set status (confirmed or cancelled). Reschedules are availability-validated and slot-locked. '
+            . 'To cancel with refund/capacity release, prefer booked_cancel_reservation.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
+    public function updateReservation(
+        int $id,
+        ?string $bookingDate = null,
+        ?string $startTime = null,
+        ?int $employeeId = null,
+        ?int $locationId = null,
+        ?string $status = null,
+        ?string $userName = null,
+        ?string $userEmail = null,
+        ?string $userPhone = null,
+        ?string $notes = null,
+    ): array {
+        return $this->guard(function() use ($id, $bookingDate, $startTime, $employeeId, $locationId, $status, $userName, $userEmail, $userPhone, $notes): array {
+            $data = array_filter([
+                'bookingDate' => $bookingDate,
+                'startTime' => $startTime,
+                'employeeId' => $employeeId,
+                'locationId' => $locationId,
+                'status' => $status,
+                'userName' => $userName,
+                'userEmail' => $userEmail,
+                'userPhone' => $userPhone,
+                'notes' => $notes,
+            ], static fn($v) => $v !== null);
+
+            if ($data === []) {
+                return ['error' => 'Provide at least one field to update.'];
+            }
+
+            $reservation = Booked::getInstance()->getBooking()->updateReservation($id, $data);
+
+            return ['success' => true, 'reservation' => Presenter::reservation($reservation)];
+        });
+    }
+
+    /**
+     * @param int $id Reservation id.
+     * @param int $reduceBy How many spots/seats to release.
+     * @param string $reason Optional reason recorded against the change.
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_reduce_reservation_quantity',
+        description: 'Reduce the quantity (spots/seats) of a reservation, releasing capacity. '
+            . 'Triggers a partial refund when Commerce is enabled.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
+    public function reduceReservationQuantity(int $id, int $reduceBy, string $reason = ''): array
+    {
+        return $this->guard(static fn(): array => [
+            'success' => Booked::getInstance()->getBooking()->reduceQuantity($id, $reduceBy, $reason),
+            'id' => $id,
+        ]);
+    }
+
+    /**
+     * @param int $id Reservation id.
+     * @param int $increaseBy How many additional spots/seats to add.
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_increase_reservation_quantity',
+        description: 'Increase the quantity (spots/seats) of a reservation, re-checking capacity for the slot.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
+    public function increaseReservationQuantity(int $id, int $increaseBy): array
+    {
+        return $this->guard(static fn(): array => [
+            'success' => Booked::getInstance()->getBooking()->increaseQuantity($id, $increaseBy),
+            'id' => $id,
+        ]);
+    }
+
+    /**
+     * Issue a full refund for a reservation through Craft Commerce. Requires the
+     * Commerce integration to be enabled.
+     *
+     * @param int $id Reservation to refund.
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_refund_reservation',
+        description: 'Issue a full Commerce refund for a reservation. Only available when Booked\'s Commerce '
+            . 'integration is enabled.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
+    public function refundReservation(int $id): array
+    {
+        return $this->guard(function() use ($id): array {
+            $booked = Booked::getInstance();
+            if (!$booked->isCommerceEnabled()) {
+                return ['error' => 'Commerce integration is not enabled; refunds are unavailable.'];
+            }
+
+            $reservation = $booked->getBooking()->getReservationById($id);
+            if (!$reservation instanceof ReservationInterface) {
+                return ['error' => "Reservation #{$id} not found."];
+            }
+
+            return [
+                'success' => $booked->getRefund()->processFullRefund($reservation),
+                'id' => $id,
+            ];
+        });
+    }
+}

--- a/src/mcp/ReservationTools.php
+++ b/src/mcp/ReservationTools.php
@@ -170,6 +170,10 @@ class ReservationTools
             $quantity,
             $userTimezone,
         ): array {
+            if (!$this->withinRateLimit('notify', 120)) {
+                return ['error' => 'Booked MCP notification rate limit reached (120/hour); pause before creating more bookings.'];
+            }
+
             $reservation = Booked::getInstance()->getBooking()->createReservation([
                 'serviceId' => $serviceId,
                 'bookingDate' => $bookingDate,
@@ -215,6 +219,10 @@ class ReservationTools
         int $quantity = 1,
     ): array {
         return $this->guard(function() use ($eventDateId, $userName, $userEmail, $userPhone, $quantity): array {
+            if (!$this->withinRateLimit('notify', 120)) {
+                return ['error' => 'Booked MCP notification rate limit reached (120/hour); pause before creating more bookings.'];
+            }
+
             $reservation = Booked::getInstance()->getBooking()->createReservation([
                 'eventDateId' => $eventDateId,
                 'userName' => $userName,
@@ -245,6 +253,10 @@ class ReservationTools
     public function cancelReservation(int $id, string $reason = ''): array
     {
         return $this->guard(function() use ($id, $reason): array {
+            if (!$this->withinRateLimit('notify', 120)) {
+                return ['error' => 'Booked MCP notification rate limit reached (120/hour); pause before cancelling more bookings.'];
+            }
+
             $ok = Booked::getInstance()->getBooking()->cancelReservation($id, $reason);
 
             return [

--- a/src/mcp/ReservationTools.php
+++ b/src/mcp/ReservationTools.php
@@ -55,8 +55,8 @@ class ReservationTools
             $query = ReservationFactory::find()
                 ->siteId('*')
                 ->status(null)
-                ->limit($limit)
-                ->offset($offset);
+                ->limit($this->clampLimit($limit))
+                ->offset($this->clampOffset($offset));
 
             if ($status !== null) {
                 $query->reservationStatus($status);
@@ -162,7 +162,7 @@ class ReservationTools
         int $quantity = 1,
         ?string $userTimezone = null,
     ): array {
-        return $this->guard(function() use (
+        return $this->guardWrite(function() use (
             $serviceId,
             $bookingDate,
             $startTime,
@@ -228,7 +228,7 @@ class ReservationTools
         ?string $userPhone = null,
         int $quantity = 1,
     ): array {
-        return $this->guard(function() use ($eventDateId, $userName, $userEmail, $userPhone, $quantity): array {
+        return $this->guardWrite(function() use ($eventDateId, $userName, $userEmail, $userPhone, $quantity): array {
             if ($quantity < 1) {
                 return ['error' => 'quantity must be at least 1.'];
             }
@@ -267,7 +267,7 @@ class ReservationTools
     #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
     public function cancelReservation(int $id, string $reason = ''): array
     {
-        return $this->guard(function() use ($id, $reason): array {
+        return $this->guardWrite(function() use ($id, $reason): array {
             if ($this->rateLimitReached()) {
                 return $this->rateLimitError('cancelling more bookings');
             }
@@ -323,7 +323,7 @@ class ReservationTools
         ?string $userPhone = null,
         ?string $notes = null,
     ): array {
-        return $this->guard(function() use ($id, $bookingDate, $startTime, $employeeId, $locationId, $status, $userName, $userEmail, $userPhone, $notes): array {
+        return $this->guardWrite(function() use ($id, $bookingDate, $startTime, $employeeId, $locationId, $status, $userName, $userEmail, $userPhone, $notes): array {
             // Flipping status to cancelled here skips the refund, capacity
             // release and waitlist notify that executeCancellation() runs.
             if ($status === 'cancelled') {
@@ -380,7 +380,7 @@ class ReservationTools
     #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
     public function reduceReservationQuantity(int $id, int $reduceBy, string $reason = ''): array
     {
-        return $this->guard(function() use ($id, $reduceBy, $reason): array {
+        return $this->guardWrite(function() use ($id, $reduceBy, $reason): array {
             // Notifies the waitlist and emails the customer (and refunds under Commerce).
             if ($this->rateLimitReached()) {
                 return $this->rateLimitError('changing more reservation quantities');
@@ -407,7 +407,7 @@ class ReservationTools
     #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
     public function increaseReservationQuantity(int $id, int $increaseBy): array
     {
-        return $this->guard(function() use ($id, $increaseBy): array {
+        return $this->guardWrite(function() use ($id, $increaseBy): array {
             if ($this->rateLimitReached()) {
                 return $this->rateLimitError('changing more reservation quantities');
             }
@@ -436,8 +436,16 @@ class ReservationTools
     #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
     public function refundReservation(int $id): array
     {
-        return $this->guard(function() use ($id): array {
+        return $this->guardWrite(function() use ($id): array {
             $booked = Booked::getInstance();
+            // Refunds move real money, so they need their own opt-in on top of the
+            // general MCP write gate enforced by guardWrite().
+            if (!$booked->getSettings()->mcpAllowRefunds) {
+                return ['error' =>
+                    'Booked MCP refunds are disabled. An administrator must enable '
+                    . '"Allow MCP refunds" in Booked\'s settings before this tool can be used.',
+                ];
+            }
             if (!$booked->isCommerceEnabled()) {
                 return ['error' => 'Commerce integration is not enabled; refunds are unavailable.'];
             }

--- a/src/mcp/ScheduleTools.php
+++ b/src/mcp/ScheduleTools.php
@@ -34,7 +34,7 @@ class ScheduleTools
     public function listSchedules(int $limit = 50): array
     {
         return $this->guard(function() use ($limit): array {
-            $schedules = Schedule::find()->siteId('*')->status(null)->limit($limit)->all();
+            $schedules = Schedule::find()->siteId('*')->status(null)->limit($this->clampLimit($limit))->all();
 
             return [
                 'count' => count($schedules),
@@ -83,7 +83,7 @@ class ScheduleTools
         ?string $startDate = null,
         ?string $endDate = null,
     ): array {
-        return $this->guard(function() use ($title, $workingHours, $startDate, $endDate): array {
+        return $this->guardWrite(function() use ($title, $workingHours, $startDate, $endDate): array {
             $schedule = new Schedule();
             $schedule->title = $title;
             $schedule->workingHours = $workingHours ?? [];
@@ -117,7 +117,7 @@ class ScheduleTools
         ?string $endDate = null,
         ?bool $enabled = null,
     ): array {
-        return $this->guard(function() use ($id, $title, $workingHours, $startDate, $endDate, $enabled): array {
+        return $this->guardWrite(function() use ($id, $title, $workingHours, $startDate, $endDate, $enabled): array {
             $schedule = Schedule::find()->siteId('*')->status(null)->id($id)->one();
             if (!$schedule instanceof Schedule) {
                 return ['error' => "Schedule #{$id} not found."];
@@ -178,7 +178,7 @@ class ScheduleTools
     #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
     public function setEmployeeSchedules(int $employeeId, array $scheduleIds): array
     {
-        return $this->guard(static fn(): array => [
+        return $this->guardWrite(static fn(): array => [
             'success' => Booked::getInstance()->getScheduleAssignment()->setSchedulesForEmployee($employeeId, $scheduleIds),
             'employeeId' => $employeeId,
             'scheduleIds' => $scheduleIds,

--- a/src/mcp/ScheduleTools.php
+++ b/src/mcp/ScheduleTools.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace anvildev\booked\mcp;
+
+use anvildev\booked\Booked;
+use anvildev\booked\elements\Schedule;
+use anvildev\booked\mcp\support\Presenter;
+use Craft;
+use Mcp\Capability\Attribute\McpTool;
+use Mcp\Capability\Attribute\Schema;
+use stimmt\craft\Mcp\attributes\McpToolMeta;
+use stimmt\craft\Mcp\enums\ToolCategory;
+
+/**
+ * MCP tools for availability schedules and their assignment to employees.
+ *
+ * A schedule holds a weekly working-hours pattern (optionally bounded by a
+ * date range) and can be shared across employees/services. Working hours are a
+ * map keyed "1"(Mon)–"7"(Sun), each `{enabled, start, end, breakStart?,
+ * breakEnd?}`; a per-day `capacity` may also be set.
+ */
+class ScheduleTools
+{
+    use ToolResponseTrait;
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_list_schedules',
+        description: 'List Booked availability schedules (weekly working-hours patterns) with their date bounds.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function listSchedules(int $limit = 50): array
+    {
+        return $this->guard(function() use ($limit): array {
+            $schedules = Schedule::find()->siteId('*')->status(null)->limit($limit)->all();
+
+            return [
+                'count' => count($schedules),
+                'schedules' => array_map(static fn(Schedule $s) => Presenter::schedule($s), $schedules),
+            ];
+        });
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_get_schedule',
+        description: 'Get a single Booked schedule by id, including its working-hours map.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function getSchedule(int $id): array
+    {
+        return $this->guard(function() use ($id): array {
+            $schedule = Schedule::find()->siteId('*')->status(null)->id($id)->one();
+            if (!$schedule instanceof Schedule) {
+                return ['error' => "Schedule #{$id} not found."];
+            }
+
+            return ['schedule' => Presenter::schedule($schedule)];
+        });
+    }
+
+    /**
+     * Create an availability schedule.
+     *
+     * @param string $title Schedule name (required).
+     * @param array<string, mixed>|null $workingHours Per-day map keyed "1"(Mon)–"7"(Sun), each {enabled, start, end, breakStart?, breakEnd?}.
+     * @param string|null $startDate Date the schedule starts applying, Y-m-d (null = always).
+     * @param string|null $endDate Date the schedule stops applying, Y-m-d (null = open-ended).
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_create_schedule',
+        description: 'Create a Booked availability schedule (weekly working-hours pattern). Returns the created schedule.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
+    public function createSchedule(
+        string $title,
+        #[Schema(type: 'object')] ?array $workingHours = null,
+        ?string $startDate = null,
+        ?string $endDate = null,
+    ): array {
+        return $this->guard(function() use ($title, $workingHours, $startDate, $endDate): array {
+            $schedule = new Schedule();
+            $schedule->title = $title;
+            $schedule->workingHours = $workingHours ?? [];
+            $schedule->startDate = $startDate;
+            $schedule->endDate = $endDate;
+
+            if (!Craft::$app->getElements()->saveElement($schedule)) {
+                return ['error' => 'Failed to create schedule.', 'validationErrors' => $schedule->getErrors()];
+            }
+
+            return ['success' => true, 'schedule' => Presenter::schedule($schedule)];
+        });
+    }
+
+    /**
+     * Update a schedule. Only provided (non-null) fields change.
+     *
+     * @param array<string, mixed>|null $workingHours Replacement working-hours map.
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_update_schedule',
+        description: 'Update a Booked schedule by id. Only the fields you pass are changed.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
+    public function updateSchedule(
+        int $id,
+        ?string $title = null,
+        #[Schema(type: 'object')] ?array $workingHours = null,
+        ?string $startDate = null,
+        ?string $endDate = null,
+        ?bool $enabled = null,
+    ): array {
+        return $this->guard(function() use ($id, $title, $workingHours, $startDate, $endDate, $enabled): array {
+            $schedule = Schedule::find()->siteId('*')->status(null)->id($id)->one();
+            if (!$schedule instanceof Schedule) {
+                return ['error' => "Schedule #{$id} not found."];
+            }
+
+            foreach ([
+                'title' => $title,
+                'workingHours' => $workingHours,
+                'startDate' => $startDate,
+                'endDate' => $endDate,
+                'enabled' => $enabled,
+            ] as $field => $value) {
+                if ($value !== null) {
+                    $schedule->$field = $value;
+                }
+            }
+
+            if (!Craft::$app->getElements()->saveElement($schedule)) {
+                return ['error' => 'Failed to update schedule.', 'validationErrors' => $schedule->getErrors()];
+            }
+
+            return ['success' => true, 'schedule' => Presenter::schedule($schedule)];
+        });
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_get_employee_schedules',
+        description: 'List the schedules assigned to an employee, in priority order.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function getEmployeeSchedules(int $employeeId): array
+    {
+        return $this->guard(function() use ($employeeId): array {
+            $schedules = Booked::getInstance()->getScheduleAssignment()->getSchedulesForEmployee($employeeId);
+
+            return [
+                'employeeId' => $employeeId,
+                'count' => count($schedules),
+                'schedules' => array_map(static fn(Schedule $s) => Presenter::schedule($s), $schedules),
+            ];
+        });
+    }
+
+    /**
+     * Replace the full set of schedules assigned to an employee.
+     *
+     * @param int $employeeId Employee to assign schedules to.
+     * @param int[] $scheduleIds Schedule ids, in priority order (first = highest).
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_set_employee_schedules',
+        description: 'Set (replace) the schedules assigned to an employee. Order is priority order.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
+    public function setEmployeeSchedules(int $employeeId, array $scheduleIds): array
+    {
+        return $this->guard(static fn(): array => [
+            'success' => Booked::getInstance()->getScheduleAssignment()->setSchedulesForEmployee($employeeId, $scheduleIds),
+            'employeeId' => $employeeId,
+            'scheduleIds' => $scheduleIds,
+        ]);
+    }
+}

--- a/src/mcp/ServiceExtraTools.php
+++ b/src/mcp/ServiceExtraTools.php
@@ -30,10 +30,14 @@ class ServiceExtraTools
         description: 'List all Booked service extras (bookable add-ons) with price, duration and required flag.',
     )]
     #[McpToolMeta(category: ToolCategory::PLUGIN)]
-    public function listServiceExtras(): array
+    public function listServiceExtras(int $limit = 50, int $offset = 0): array
     {
-        return $this->guard(static function(): array {
-            $extras = Booked::getInstance()->getServiceExtra()->getAllExtras(false);
+        return $this->guard(function() use ($limit, $offset): array {
+            $extras = Booked::getInstance()->getServiceExtra()->getAllExtras(
+                false,
+                $this->clampLimit($limit),
+                $this->clampOffset($offset),
+            );
 
             return [
                 'count' => count($extras),
@@ -66,7 +70,7 @@ class ServiceExtraTools
         bool $isRequired = false,
         ?string $description = null,
     ): array {
-        return $this->guard(function() use ($title, $price, $duration, $maxQuantity, $isRequired, $description): array {
+        return $this->guardWrite(function() use ($title, $price, $duration, $maxQuantity, $isRequired, $description): array {
             $extra = new ServiceExtra();
             $extra->title = $title;
             $extra->price = $price;
@@ -118,7 +122,7 @@ class ServiceExtraTools
     #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
     public function setServiceExtras(int $serviceId, array $extraIds): array
     {
-        return $this->guard(static fn(): array => [
+        return $this->guardWrite(static fn(): array => [
             'success' => Booked::getInstance()->getServiceExtra()->setExtrasForService($serviceId, $extraIds),
             'serviceId' => $serviceId,
             'extraIds' => $extraIds,
@@ -160,7 +164,7 @@ class ServiceExtraTools
     #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
     public function setServiceLocations(int $serviceId, array $locationIds): array
     {
-        return $this->guard(static fn(): array => [
+        return $this->guardWrite(static fn(): array => [
             'success' => Booked::getInstance()->getServiceLocation()->setLocationsForService($serviceId, $locationIds),
             'serviceId' => $serviceId,
             'locationIds' => $locationIds,

--- a/src/mcp/ServiceExtraTools.php
+++ b/src/mcp/ServiceExtraTools.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace anvildev\booked\mcp;
+
+use anvildev\booked\Booked;
+use anvildev\booked\elements\Location;
+use anvildev\booked\elements\ServiceExtra;
+use anvildev\booked\mcp\support\Presenter;
+use Mcp\Capability\Attribute\McpTool;
+use stimmt\craft\Mcp\attributes\McpToolMeta;
+use stimmt\craft\Mcp\enums\ToolCategory;
+
+/**
+ * MCP tools for service add-ons (extras) and service↔location links.
+ *
+ * Extras are global add-ons (e.g. "gift wrap", "extra time") that are then
+ * attached to specific services; locations restrict where a service can be
+ * booked. Both go through Booked's relation services so join tables and caches
+ * stay consistent.
+ */
+class ServiceExtraTools
+{
+    use ToolResponseTrait;
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_list_service_extras',
+        description: 'List all Booked service extras (bookable add-ons) with price, duration and required flag.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function listServiceExtras(): array
+    {
+        return $this->guard(static function(): array {
+            $extras = Booked::getInstance()->getServiceExtra()->getAllExtras(false);
+
+            return [
+                'count' => count($extras),
+                'extras' => array_map(static fn(ServiceExtra $e) => Presenter::serviceExtra($e), $extras),
+            ];
+        });
+    }
+
+    /**
+     * Create a service extra (add-on).
+     *
+     * @param string $title Name of the extra (required).
+     * @param float $price Price of the extra.
+     * @param int $duration Additional duration in minutes this extra adds to a booking.
+     * @param int $maxQuantity Maximum quantity bookable per reservation.
+     * @param bool $isRequired Whether the extra is mandatory for services it is attached to.
+     * @param string|null $description Optional description.
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_create_service_extra',
+        description: 'Create a Booked service extra (add-on). Attach it to services with booked_set_service_extras.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
+    public function createServiceExtra(
+        string $title,
+        float $price = 0.0,
+        int $duration = 0,
+        int $maxQuantity = 1,
+        bool $isRequired = false,
+        ?string $description = null,
+    ): array {
+        return $this->guard(function() use ($title, $price, $duration, $maxQuantity, $isRequired, $description): array {
+            $extra = new ServiceExtra();
+            $extra->title = $title;
+            $extra->price = $price;
+            $extra->duration = $duration;
+            $extra->maxQuantity = $maxQuantity;
+            $extra->isRequired = $isRequired;
+            $extra->description = $description;
+
+            if (!Booked::getInstance()->getServiceExtra()->saveExtra($extra)) {
+                return ['error' => 'Failed to create service extra.', 'validationErrors' => $extra->getErrors()];
+            }
+
+            return ['success' => true, 'extra' => Presenter::serviceExtra($extra)];
+        });
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_get_service_extras',
+        description: 'List the extras attached to a specific service.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function getServiceExtras(int $serviceId, bool $enabledOnly = false): array
+    {
+        return $this->guard(function() use ($serviceId, $enabledOnly): array {
+            $extras = Booked::getInstance()->getServiceExtra()->getExtrasForService($serviceId, $enabledOnly);
+
+            return [
+                'serviceId' => $serviceId,
+                'count' => count($extras),
+                'extras' => array_map(static fn(ServiceExtra $e) => Presenter::serviceExtra($e), $extras),
+            ];
+        });
+    }
+
+    /**
+     * Replace the set of extras attached to a service.
+     *
+     * @param int $serviceId Service to attach extras to.
+     * @param int[] $extraIds Extra ids to attach (replaces the current set).
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_set_service_extras',
+        description: 'Set (replace) the extras attached to a service.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
+    public function setServiceExtras(int $serviceId, array $extraIds): array
+    {
+        return $this->guard(static fn(): array => [
+            'success' => Booked::getInstance()->getServiceExtra()->setExtrasForService($serviceId, $extraIds),
+            'serviceId' => $serviceId,
+            'extraIds' => $extraIds,
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_get_service_locations',
+        description: 'List the locations a service can be booked at.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function getServiceLocations(int $serviceId): array
+    {
+        return $this->guard(function() use ($serviceId): array {
+            $locations = Booked::getInstance()->getServiceLocation()->getLocationsForService($serviceId);
+
+            return [
+                'serviceId' => $serviceId,
+                'count' => count($locations),
+                'locations' => array_map(static fn(Location $l) => Presenter::location($l), $locations),
+            ];
+        });
+    }
+
+    /**
+     * Replace the set of locations a service can be booked at.
+     *
+     * @param int $serviceId Service to set locations for.
+     * @param int[] $locationIds Location ids (replaces the current set; empty = all locations).
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_set_service_locations',
+        description: 'Set (replace) the locations a service can be booked at. Empty list means all locations.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
+    public function setServiceLocations(int $serviceId, array $locationIds): array
+    {
+        return $this->guard(static fn(): array => [
+            'success' => Booked::getInstance()->getServiceLocation()->setLocationsForService($serviceId, $locationIds),
+            'serviceId' => $serviceId,
+            'locationIds' => $locationIds,
+        ]);
+    }
+}

--- a/src/mcp/ToolResponseTrait.php
+++ b/src/mcp/ToolResponseTrait.php
@@ -35,10 +35,40 @@ trait ToolResponseTrait
             return $result;
         } catch (Throwable $e) {
             Craft::warning('Booked MCP tool failed: ' . $e->getMessage(), __METHOD__);
+
+            // Only Booked's own typed exceptions carry client-safe, intentional messages.
+            // Everything else (PDO/Yii/driver/internal) may embed SQL, schema or paths,
+            // so it is reduced to a generic message — details stay in the server logs.
+            $isBookedException = str_starts_with($e::class, 'anvildev\\booked\\exceptions\\');
+
             return [
-                'error' => $e->getMessage(),
+                'error' => $isBookedException
+                    ? $e->getMessage()
+                    : 'An internal error occurred while running the tool; see the Booked/Craft logs for details.',
                 'type' => (new \ReflectionClass($e))->getShortName(),
             ];
         }
+    }
+
+    /**
+     * Cache-backed throttle for tools that send real notifications (email/SMS).
+     *
+     * Booked's own rate limiting is IP-keyed and unreachable in the MCP/console
+     * context, so without this an untrusted client could loop a notifying tool
+     * and spam arbitrary addresses. Returns false once $max calls have been
+     * recorded for $key within the rolling window.
+     */
+    private function withinRateLimit(string $key, int $max, int $windowSeconds = 3600): bool
+    {
+        $cache = Craft::$app->getCache();
+        $cacheKey = "booked:mcp:ratelimit:{$key}";
+        $count = (int)$cache->get($cacheKey);
+
+        if ($count >= $max) {
+            return false;
+        }
+
+        $cache->set($cacheKey, $count + 1, $windowSeconds);
+        return true;
     }
 }

--- a/src/mcp/ToolResponseTrait.php
+++ b/src/mcp/ToolResponseTrait.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace anvildev\booked\mcp;
+
+use anvildev\booked\mcp\support\Presenter;
+use Craft;
+use Throwable;
+
+/**
+ * Shared error handling for Booked's MCP tools.
+ *
+ * Booked's services throw typed exceptions (validation, conflict, not-found)
+ * to drive the booking flow. Over MCP we never want those to surface as a
+ * transport-level fault; {@see self::guard()} converts any throwable into a
+ * structured `['error' => …]` payload the AI client can read and react to.
+ *
+ * The trait deliberately references nothing from the craft-mcp package, so a
+ * tool class is fully usable (and unit-testable) even when that plugin is not
+ * installed — the `#[McpTool]` attributes are only read reflectively by the
+ * craft-mcp registry when it is present.
+ */
+trait ToolResponseTrait
+{
+    /**
+     * Run a tool body, translating exceptions into an error response.
+     *
+     * @param \Closure(): array<string, mixed> $fn
+     * @return array<string, mixed>
+     */
+    private function guard(\Closure $fn): array
+    {
+        try {
+            /** @var array<string, mixed> $result */
+            $result = Presenter::jsonSafe($fn());
+            return $result;
+        } catch (Throwable $e) {
+            Craft::warning('Booked MCP tool failed: ' . $e->getMessage(), __METHOD__);
+            return [
+                'error' => $e->getMessage(),
+                'type' => (new \ReflectionClass($e))->getShortName(),
+            ];
+        }
+    }
+}

--- a/src/mcp/ToolResponseTrait.php
+++ b/src/mcp/ToolResponseTrait.php
@@ -50,25 +50,68 @@ trait ToolResponseTrait
         }
     }
 
+    private const RATE_LIMIT_MAX = 120;
+    private const RATE_LIMIT_WINDOW = 3600;
+
     /**
-     * Cache-backed throttle for tools that send real notifications (email/SMS).
+     * Throttle for tools with real side effects (email/SMS/refunds), since
+     * Booked's own IP-keyed rate limiting is unreachable in the MCP/console
+     * context. Split into this peek and {@see self::recordRateLimitedCall()} so
+     * callers record only after the operation succeeds — a failed call never
+     * burns a slot. Distinct $keys ('notify', 'refund') keep one class of
+     * side effect from locking out another.
      *
-     * Booked's own rate limiting is IP-keyed and unreachable in the MCP/console
-     * context, so without this an untrusted client could loop a notifying tool
-     * and spam arbitrary addresses. Returns false once $max calls have been
-     * recorded for $key within the rolling window.
+     * Peek only: returns true when the budget for $key is already exhausted.
      */
-    private function withinRateLimit(string $key, int $max, int $windowSeconds = 3600): bool
+    private function rateLimitReached(string $key = 'notify', int $max = self::RATE_LIMIT_MAX): bool
+    {
+        $bucket = Craft::$app->getCache()->get("booked:mcp:ratelimit:{$key}");
+        return is_array($bucket) && (int)($bucket['count'] ?? 0) >= $max;
+    }
+
+    /**
+     * Record one successful call against the counter for $key. The window end is
+     * pinned in the payload so later calls never extend the TTL (a fixed window,
+     * not a sliding one), and the read-modify-write is mutex-serialised so
+     * concurrent calls can't both slip past the ceiling.
+     */
+    private function recordRateLimitedCall(string $key = 'notify', int $windowSeconds = self::RATE_LIMIT_WINDOW): void
     {
         $cache = Craft::$app->getCache();
         $cacheKey = "booked:mcp:ratelimit:{$key}";
-        $count = (int)$cache->get($cacheKey);
+        $mutex = Craft::$app->getMutex();
+        $lockKey = "booked:mcp:ratelimit-lock:{$key}";
+        $locked = $mutex->acquire($lockKey, 2);
 
-        if ($count >= $max) {
-            return false;
+        try {
+            $now = time();
+            $bucket = $cache->get($cacheKey);
+            if (!is_array($bucket) || (int)($bucket['expiresAt'] ?? 0) <= $now) {
+                $cache->set($cacheKey, ['count' => 1, 'expiresAt' => $now + $windowSeconds], $windowSeconds);
+                return;
+            }
+
+            $bucket['count'] = (int)$bucket['count'] + 1;
+            // TTL tracks the original window end, never reset.
+            $cache->set($cacheKey, $bucket, max(1, (int)$bucket['expiresAt'] - $now));
+        } finally {
+            if ($locked) {
+                $mutex->release($lockKey);
+            }
         }
+    }
 
-        $cache->set($cacheKey, $count + 1, $windowSeconds);
-        return true;
+    /**
+     * Standard rate-limit error payload.
+     *
+     * @return array{error: string}
+     */
+    private function rateLimitError(string $action): array
+    {
+        return ['error' => sprintf(
+            'Booked MCP rate limit reached (%d/hour); pause before %s.',
+            self::RATE_LIMIT_MAX,
+            $action,
+        )];
     }
 }

--- a/src/mcp/ToolResponseTrait.php
+++ b/src/mcp/ToolResponseTrait.php
@@ -2,6 +2,7 @@
 
 namespace anvildev\booked\mcp;
 
+use anvildev\booked\Booked;
 use anvildev\booked\mcp\support\Presenter;
 use Craft;
 use Throwable;
@@ -48,6 +49,83 @@ trait ToolResponseTrait
                 'type' => (new \ReflectionClass($e))->getShortName(),
             ];
         }
+    }
+
+    /**
+     * Run a *mutating* tool body behind Booked's MCP write authorization.
+     *
+     * Reads go through {@see self::guard()}; anything that creates, edits,
+     * cancels or deletes goes through this. The craft-mcp server config (allowed
+     * IPs / dangerous-tool gate) is the transport-level boundary, but Booked must
+     * not rely on it alone for destructive operations — so write tools are
+     * additionally gated by an admin-controlled, default-off plugin setting, and,
+     * when an authenticated Control-Panel user is present (web-context MCP), by
+     * the same `booked-manageBookings` permission the CP enforces.
+     *
+     * @param \Closure(): array<string, mixed> $fn
+     * @return array<string, mixed>
+     */
+    private function guardWrite(\Closure $fn): array
+    {
+        $denied = $this->authorizeWrite();
+        if ($denied !== null) {
+            return $denied;
+        }
+
+        return $this->guard($fn);
+    }
+
+    /**
+     * Returns an error payload when the caller may not perform MCP write
+     * operations, or null when the operation is allowed to proceed.
+     *
+     * @return array{error: string}|null
+     */
+    private function authorizeWrite(): ?array
+    {
+        if (!Booked::getInstance()->getSettings()->mcpWriteEnabled) {
+            return ['error' =>
+                'Booked MCP write operations are disabled. An administrator must enable '
+                . '"Allow MCP write operations" in Booked\'s settings before this tool can be used.',
+            ];
+        }
+
+        // Defense in depth: in a web context an authenticated user is present, so
+        // require the same permission the Control Panel does. In console/stdio
+        // context there is no user — the setting above is the control there.
+        $user = Craft::$app instanceof \craft\web\Application
+            ? Craft::$app->getUser()->getIdentity()
+            : null;
+        if ($user !== null && !$user->admin && !$user->can('booked-manageBookings')) {
+            return ['error' => 'Not authorized: the booked-manageBookings permission is required for this operation.'];
+        }
+
+        return null;
+    }
+
+    /**
+     * Hard ceiling for list/pagination tools, so a single MCP call can never
+     * materialise an unbounded result set (memory exhaustion + bulk PII export).
+     */
+    private const LIST_LIMIT_MAX = 200;
+    private const LIST_LIMIT_DEFAULT = 50;
+
+    /**
+     * Clamp a caller-supplied page size into [1, LIST_LIMIT_MAX]; out-of-range or
+     * non-positive values fall back to the default page size.
+     */
+    private function clampLimit(int $limit, int $max = self::LIST_LIMIT_MAX): int
+    {
+        if ($limit < 1) {
+            return self::LIST_LIMIT_DEFAULT;
+        }
+
+        return min($limit, $max);
+    }
+
+    private function clampOffset(int $offset): int
+    {
+        return max(0, $offset);
     }
 
     private const RATE_LIMIT_MAX = 120;

--- a/src/mcp/WaitlistTools.php
+++ b/src/mcp/WaitlistTools.php
@@ -26,10 +26,14 @@ class WaitlistTools
         description: 'List active waitlist entries for a service, in priority order.',
     )]
     #[McpToolMeta(category: ToolCategory::PLUGIN)]
-    public function listWaitlist(int $serviceId): array
+    public function listWaitlist(int $serviceId, int $limit = 50, int $offset = 0): array
     {
-        return $this->guard(function() use ($serviceId): array {
-            $entries = Booked::getInstance()->getWaitlist()->getActiveEntriesForService($serviceId);
+        return $this->guard(function() use ($serviceId, $limit, $offset): array {
+            $entries = Booked::getInstance()->getWaitlist()->getActiveEntriesForService(
+                $serviceId,
+                $this->clampLimit($limit),
+                $this->clampOffset($offset),
+            );
 
             return [
                 'serviceId' => $serviceId,
@@ -86,7 +90,7 @@ class WaitlistTools
         ?string $preferredTimeEnd = null,
         ?string $notes = null,
     ): array {
-        return $this->guard(function() use ($serviceId, $userName, $userEmail, $userPhone, $employeeId, $locationId, $preferredDate, $preferredTimeStart, $preferredTimeEnd, $notes): array {
+        return $this->guardWrite(function() use ($serviceId, $userName, $userEmail, $userPhone, $employeeId, $locationId, $preferredDate, $preferredTimeStart, $preferredTimeEnd, $notes): array {
             if ($this->rateLimitReached()) {
                 return $this->rateLimitError('adding more waitlist entries');
             }
@@ -136,7 +140,7 @@ class WaitlistTools
         ?string $userPhone = null,
         ?string $notes = null,
     ): array {
-        return $this->guard(function() use ($eventDateId, $userName, $userEmail, $userPhone, $notes): array {
+        return $this->guardWrite(function() use ($eventDateId, $userName, $userEmail, $userPhone, $notes): array {
             if ($this->rateLimitReached()) {
                 return $this->rateLimitError('adding more waitlist entries');
             }
@@ -170,7 +174,7 @@ class WaitlistTools
     #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
     public function cancelWaitlistEntry(int $entryId): array
     {
-        return $this->guard(static fn(): array => [
+        return $this->guardWrite(static fn(): array => [
             'success' => Booked::getInstance()->getWaitlist()->cancelEntry($entryId),
             'entryId' => $entryId,
         ]);
@@ -189,7 +193,7 @@ class WaitlistTools
     #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
     public function notifyWaitlistEntry(int $entryId): array
     {
-        return $this->guard(function() use ($entryId): array {
+        return $this->guardWrite(function() use ($entryId): array {
             if ($this->rateLimitReached()) {
                 return $this->rateLimitError('sending more waitlist notifications');
             }

--- a/src/mcp/WaitlistTools.php
+++ b/src/mcp/WaitlistTools.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace anvildev\booked\mcp;
+
+use anvildev\booked\Booked;
+use anvildev\booked\mcp\support\Presenter;
+use anvildev\booked\records\WaitlistRecord;
+use Mcp\Capability\Attribute\McpTool;
+use stimmt\craft\Mcp\attributes\McpToolMeta;
+use stimmt\craft\Mcp\enums\ToolCategory;
+
+/**
+ * MCP tools for the booking waitlist — both service waitlists (a customer
+ * waiting for any/specific slot of a service) and event waitlists (waiting for
+ * a seat on a full event date).
+ */
+class WaitlistTools
+{
+    use ToolResponseTrait;
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_list_waitlist',
+        description: 'List active waitlist entries for a service, in priority order.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function listWaitlist(int $serviceId): array
+    {
+        return $this->guard(function() use ($serviceId): array {
+            $entries = Booked::getInstance()->getWaitlist()->getActiveEntriesForService($serviceId);
+
+            return [
+                'serviceId' => $serviceId,
+                'count' => count($entries),
+                'entries' => array_map(static fn(WaitlistRecord $e) => Presenter::waitlistEntry($e, redactPii: true), $entries),
+            ];
+        });
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_waitlist_stats',
+        description: 'Aggregate waitlist statistics (active/notified/converted/expired counts).',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN)]
+    public function waitlistStats(): array
+    {
+        return $this->guard(static fn(): array => [
+            'stats' => Booked::getInstance()->getWaitlist()->getStats(),
+        ]);
+    }
+
+    /**
+     * Add a customer to a service waitlist.
+     *
+     * @param int $serviceId Service to wait for.
+     * @param string $userName Customer name.
+     * @param string $userEmail Customer email.
+     * @param string|null $userPhone Customer phone.
+     * @param int|null $employeeId Preferred employee.
+     * @param int|null $locationId Preferred location.
+     * @param string|null $preferredDate Preferred date, Y-m-d.
+     * @param string|null $preferredTimeStart Preferred earliest time, HH:MM.
+     * @param string|null $preferredTimeEnd Preferred latest time, HH:MM.
+     * @param string|null $notes Free-text notes.
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_add_to_waitlist',
+        description: 'Add a customer to a service waitlist, with optional preferred employee/location/date/time.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
+    public function addToWaitlist(
+        int $serviceId,
+        string $userName,
+        string $userEmail,
+        ?string $userPhone = null,
+        ?int $employeeId = null,
+        ?int $locationId = null,
+        ?string $preferredDate = null,
+        ?string $preferredTimeStart = null,
+        ?string $preferredTimeEnd = null,
+        ?string $notes = null,
+    ): array {
+        return $this->guard(function() use ($serviceId, $userName, $userEmail, $userPhone, $employeeId, $locationId, $preferredDate, $preferredTimeStart, $preferredTimeEnd, $notes): array {
+            $entry = Booked::getInstance()->getWaitlist()->addToWaitlist([
+                'serviceId' => $serviceId,
+                'userName' => $userName,
+                'userEmail' => $userEmail,
+                'userPhone' => $userPhone,
+                'employeeId' => $employeeId,
+                'locationId' => $locationId,
+                'preferredDate' => $preferredDate,
+                'preferredTimeStart' => $preferredTimeStart,
+                'preferredTimeEnd' => $preferredTimeEnd,
+                'notes' => $notes,
+            ]);
+
+            if (!$entry instanceof WaitlistRecord) {
+                return ['error' => 'Could not add to waitlist (already listed, or waitlist disabled for this service).'];
+            }
+
+            return ['success' => true, 'entry' => Presenter::waitlistEntry($entry)];
+        });
+    }
+
+    /**
+     * Add a customer to an event date's waitlist.
+     *
+     * @param int $eventDateId Event date to wait for.
+     * @param string $userName Customer name.
+     * @param string $userEmail Customer email.
+     * @param string|null $userPhone Customer phone.
+     * @param string|null $notes Free-text notes.
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_add_to_event_waitlist',
+        description: 'Add a customer to the waitlist for a full event date.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
+    public function addToEventWaitlist(
+        int $eventDateId,
+        string $userName,
+        string $userEmail,
+        ?string $userPhone = null,
+        ?string $notes = null,
+    ): array {
+        return $this->guard(function() use ($eventDateId, $userName, $userEmail, $userPhone, $notes): array {
+            $entry = Booked::getInstance()->getWaitlist()->addToEventWaitlist([
+                'eventDateId' => $eventDateId,
+                'userName' => $userName,
+                'userEmail' => $userEmail,
+                'userPhone' => $userPhone,
+                'notes' => $notes,
+            ]);
+
+            if (!$entry instanceof WaitlistRecord) {
+                return ['error' => 'Could not add to event waitlist (already listed, or waitlist disabled).'];
+            }
+
+            return ['success' => true, 'entry' => Presenter::waitlistEntry($entry)];
+        });
+    }
+
+    /**
+     * @param int $entryId Waitlist entry id.
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_cancel_waitlist_entry',
+        description: 'Cancel (remove) a waitlist entry by id.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
+    public function cancelWaitlistEntry(int $entryId): array
+    {
+        return $this->guard(static fn(): array => [
+            'success' => Booked::getInstance()->getWaitlist()->cancelEntry($entryId),
+            'entryId' => $entryId,
+        ]);
+    }
+
+    /**
+     * Manually notify a waitlist entry that a spot may be available.
+     *
+     * @param int $entryId Waitlist entry id.
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'booked_notify_waitlist_entry',
+        description: 'Manually send the "a spot is available" notification to a waitlist entry.',
+    )]
+    #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
+    public function notifyWaitlistEntry(int $entryId): array
+    {
+        return $this->guard(static fn(): array => [
+            'success' => Booked::getInstance()->getWaitlist()->manualNotify($entryId),
+            'entryId' => $entryId,
+        ]);
+    }
+}

--- a/src/mcp/WaitlistTools.php
+++ b/src/mcp/WaitlistTools.php
@@ -87,6 +87,10 @@ class WaitlistTools
         ?string $notes = null,
     ): array {
         return $this->guard(function() use ($serviceId, $userName, $userEmail, $userPhone, $employeeId, $locationId, $preferredDate, $preferredTimeStart, $preferredTimeEnd, $notes): array {
+            if (!$this->withinRateLimit('notify', 120)) {
+                return ['error' => 'Booked MCP notification rate limit reached (120/hour); pause before adding more waitlist entries.'];
+            }
+
             $entry = Booked::getInstance()->getWaitlist()->addToWaitlist([
                 'serviceId' => $serviceId,
                 'userName' => $userName,
@@ -131,6 +135,10 @@ class WaitlistTools
         ?string $notes = null,
     ): array {
         return $this->guard(function() use ($eventDateId, $userName, $userEmail, $userPhone, $notes): array {
+            if (!$this->withinRateLimit('notify', 120)) {
+                return ['error' => 'Booked MCP notification rate limit reached (120/hour); pause before adding more waitlist entries.'];
+            }
+
             $entry = Booked::getInstance()->getWaitlist()->addToEventWaitlist([
                 'eventDateId' => $eventDateId,
                 'userName' => $userName,
@@ -177,9 +185,15 @@ class WaitlistTools
     #[McpToolMeta(category: ToolCategory::PLUGIN, dangerous: true)]
     public function notifyWaitlistEntry(int $entryId): array
     {
-        return $this->guard(static fn(): array => [
-            'success' => Booked::getInstance()->getWaitlist()->manualNotify($entryId),
-            'entryId' => $entryId,
-        ]);
+        return $this->guard(function() use ($entryId): array {
+            if (!$this->withinRateLimit('notify', 120)) {
+                return ['error' => 'Booked MCP notification rate limit reached (120/hour); pause before sending more waitlist notifications.'];
+            }
+
+            return [
+                'success' => Booked::getInstance()->getWaitlist()->manualNotify($entryId),
+                'entryId' => $entryId,
+            ];
+        });
     }
 }

--- a/src/mcp/WaitlistTools.php
+++ b/src/mcp/WaitlistTools.php
@@ -87,8 +87,8 @@ class WaitlistTools
         ?string $notes = null,
     ): array {
         return $this->guard(function() use ($serviceId, $userName, $userEmail, $userPhone, $employeeId, $locationId, $preferredDate, $preferredTimeStart, $preferredTimeEnd, $notes): array {
-            if (!$this->withinRateLimit('notify', 120)) {
-                return ['error' => 'Booked MCP notification rate limit reached (120/hour); pause before adding more waitlist entries.'];
+            if ($this->rateLimitReached()) {
+                return $this->rateLimitError('adding more waitlist entries');
             }
 
             $entry = Booked::getInstance()->getWaitlist()->addToWaitlist([
@@ -107,6 +107,8 @@ class WaitlistTools
             if (!$entry instanceof WaitlistRecord) {
                 return ['error' => 'Could not add to waitlist (already listed, or waitlist disabled for this service).'];
             }
+
+            $this->recordRateLimitedCall();
 
             return ['success' => true, 'entry' => Presenter::waitlistEntry($entry)];
         });
@@ -135,8 +137,8 @@ class WaitlistTools
         ?string $notes = null,
     ): array {
         return $this->guard(function() use ($eventDateId, $userName, $userEmail, $userPhone, $notes): array {
-            if (!$this->withinRateLimit('notify', 120)) {
-                return ['error' => 'Booked MCP notification rate limit reached (120/hour); pause before adding more waitlist entries.'];
+            if ($this->rateLimitReached()) {
+                return $this->rateLimitError('adding more waitlist entries');
             }
 
             $entry = Booked::getInstance()->getWaitlist()->addToEventWaitlist([
@@ -150,6 +152,8 @@ class WaitlistTools
             if (!$entry instanceof WaitlistRecord) {
                 return ['error' => 'Could not add to event waitlist (already listed, or waitlist disabled).'];
             }
+
+            $this->recordRateLimitedCall();
 
             return ['success' => true, 'entry' => Presenter::waitlistEntry($entry)];
         });
@@ -186,12 +190,17 @@ class WaitlistTools
     public function notifyWaitlistEntry(int $entryId): array
     {
         return $this->guard(function() use ($entryId): array {
-            if (!$this->withinRateLimit('notify', 120)) {
-                return ['error' => 'Booked MCP notification rate limit reached (120/hour); pause before sending more waitlist notifications.'];
+            if ($this->rateLimitReached()) {
+                return $this->rateLimitError('sending more waitlist notifications');
+            }
+
+            $ok = Booked::getInstance()->getWaitlist()->manualNotify($entryId);
+            if ($ok) {
+                $this->recordRateLimitedCall();
             }
 
             return [
-                'success' => Booked::getInstance()->getWaitlist()->manualNotify($entryId),
+                'success' => $ok,
                 'entryId' => $entryId,
             ];
         });

--- a/src/mcp/support/Presenter.php
+++ b/src/mcp/support/Presenter.php
@@ -154,11 +154,12 @@ final class Presenter
     }
 
     /**
-     * @param bool $redactPii Mask customer email/phone — set for bulk list output, where one
-     *                        call could otherwise exfiltrate the whole customer base.
+     * @param bool $redactPii Mask customer email/phone. Defaults to true: the MCP surface never
+     *                        returns raw customer contact details unless a caller explicitly opts
+     *                        out, so a forgotten flag fails safe rather than leaking PII.
      * @return array<string, mixed>
      */
-    public static function reservation(ReservationInterface $reservation, bool $redactPii = false): array
+    public static function reservation(ReservationInterface $reservation, bool $redactPii = true): array
     {
         $email = $reservation->getUserEmail();
         $phone = $reservation->getUserPhone();
@@ -239,10 +240,11 @@ final class Presenter
     }
 
     /**
-     * @param bool $redactPii Mask customer email/phone for bulk list output.
+     * @param bool $redactPii Mask customer email/phone. Defaults to true (fail-safe); see
+     *                        {@see self::reservation()}.
      * @return array<string, mixed>
      */
-    public static function waitlistEntry(WaitlistRecord $entry, bool $redactPii = false): array
+    public static function waitlistEntry(WaitlistRecord $entry, bool $redactPii = true): array
     {
         return [
             'id' => $entry->id,

--- a/src/mcp/support/Presenter.php
+++ b/src/mcp/support/Presenter.php
@@ -34,8 +34,13 @@ final class Presenter
      * / string / public-property form. Tool responses are passed through this
      * so a tool can never crash the transport with an unserialisable result.
      */
-    public static function jsonSafe(mixed $value): mixed
+    public static function jsonSafe(mixed $value, int $depth = 0): mixed
     {
+        // Hard depth cap — guards against cyclic / self-referential objects in
+        // report/dashboard data recursing until the stack overflows.
+        if ($depth > 16) {
+            return null;
+        }
         if ($value instanceof ElementInterface) {
             return ['id' => $value->id, 'title' => $value->title ?? (string)$value];
         }
@@ -43,15 +48,22 @@ final class Presenter
             return $value->format(\DateTimeInterface::ATOM);
         }
         if (is_array($value)) {
-            return array_map(self::jsonSafe(...), $value);
+            return array_map(static fn($v) => self::jsonSafe($v, $depth + 1), $value);
         }
         if ($value instanceof \JsonSerializable) {
-            return self::jsonSafe($value->jsonSerialize());
+            return self::jsonSafe($value->jsonSerialize(), $depth + 1);
+        }
+        if ($value instanceof \stdClass) {
+            // Plain data object (e.g. decoded JSON) — safe to expand.
+            return self::jsonSafe(get_object_vars($value), $depth + 1);
         }
         if (is_object($value)) {
+            // Never dump arbitrary class internals via get_object_vars() — a report
+            // row could carry a model/config/credential object. Collapse to a string
+            // (if stringable) or an opaque class stub.
             return method_exists($value, '__toString')
                 ? (string)$value
-                : self::jsonSafe(get_object_vars($value));
+                : ['_class' => $value::class];
         }
         if (is_float($value) && !is_finite($value)) {
             return null;

--- a/src/mcp/support/Presenter.php
+++ b/src/mcp/support/Presenter.php
@@ -1,0 +1,254 @@
+<?php
+
+namespace anvildev\booked\mcp\support;
+
+use anvildev\booked\contracts\ReservationInterface;
+use anvildev\booked\elements\BlackoutDate;
+use anvildev\booked\elements\Employee;
+use anvildev\booked\elements\EventDate;
+use anvildev\booked\elements\Location;
+use anvildev\booked\elements\Schedule;
+use anvildev\booked\elements\Service;
+use anvildev\booked\elements\ServiceExtra;
+use anvildev\booked\helpers\PiiRedactor;
+use anvildev\booked\records\WaitlistRecord;
+use craft\base\ElementInterface;
+
+/**
+ * Serialises Booked elements and reservations into plain, MCP-friendly arrays.
+ *
+ * Every value returned here is JSON-safe (scalars, arrays, ISO-8601 date
+ * strings) so the MCP SDK can hand it straight to an AI client. Presenters are
+ * the single place that decides which fields are exposed over the protocol.
+ */
+final class Presenter
+{
+    /**
+     * Recursively coerce a value into something json_encode can always handle.
+     *
+     * Booked's reporting/dashboard services return arrays that embed live Craft
+     * element objects (built for Twig rendering). Those would either bloat the
+     * MCP payload or break serialisation, so any element is collapsed to a
+     * compact {id, title} stub. Dates become ISO-8601 strings, non-finite
+     * floats become null, and other objects fall back to their JsonSerializable
+     * / string / public-property form. Tool responses are passed through this
+     * so a tool can never crash the transport with an unserialisable result.
+     */
+    public static function jsonSafe(mixed $value): mixed
+    {
+        if ($value instanceof ElementInterface) {
+            return ['id' => $value->id, 'title' => $value->title ?? (string)$value];
+        }
+        if ($value instanceof \DateTimeInterface) {
+            return $value->format(\DateTimeInterface::ATOM);
+        }
+        if (is_array($value)) {
+            return array_map(self::jsonSafe(...), $value);
+        }
+        if ($value instanceof \JsonSerializable) {
+            return self::jsonSafe($value->jsonSerialize());
+        }
+        if (is_object($value)) {
+            return method_exists($value, '__toString')
+                ? (string)$value
+                : self::jsonSafe(get_object_vars($value));
+        }
+        if (is_float($value) && !is_finite($value)) {
+            return null;
+        }
+        return $value;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function service(Service $service): array
+    {
+        return [
+            'id' => $service->id,
+            'title' => $service->title,
+            'enabled' => $service->enabled,
+            'description' => $service->description,
+            'duration' => $service->duration,
+            'durationType' => $service->durationType,
+            'timeSlotLength' => $service->timeSlotLength,
+            'pricingMode' => $service->pricingMode,
+            'price' => $service->price,
+            'bufferBefore' => $service->bufferBefore,
+            'bufferAfter' => $service->bufferAfter,
+            'minTimeBeforeBooking' => $service->minTimeBeforeBooking,
+            'allowCancellation' => $service->allowCancellation,
+            'cancellationPolicyHours' => $service->cancellationPolicyHours,
+            'enableWaitlist' => $service->enableWaitlist,
+            'siteId' => $service->siteId,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function employee(Employee $employee): array
+    {
+        return [
+            'id' => $employee->id,
+            'title' => $employee->title,
+            'enabled' => $employee->enabled,
+            'email' => $employee->email,
+            'userId' => $employee->userId,
+            'locationId' => $employee->locationId,
+            'serviceIds' => $employee->serviceIds,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function location(Location $location): array
+    {
+        return [
+            'id' => $location->id,
+            'title' => $location->title,
+            'enabled' => $location->enabled,
+            'timezone' => $location->timezone,
+            'addressLine1' => $location->addressLine1,
+            'addressLine2' => $location->addressLine2,
+            'locality' => $location->locality,
+            'administrativeArea' => $location->administrativeArea,
+            'postalCode' => $location->postalCode,
+            'countryCode' => $location->countryCode,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function eventDate(EventDate $eventDate): array
+    {
+        return [
+            'id' => $eventDate->id,
+            'title' => $eventDate->title,
+            'enabled' => $eventDate->enabled,
+            'description' => $eventDate->description,
+            'eventDate' => $eventDate->eventDate,
+            'endDate' => $eventDate->endDate,
+            'startTime' => $eventDate->startTime,
+            'endTime' => $eventDate->endTime,
+            'locationId' => $eventDate->locationId,
+            'capacity' => $eventDate->capacity,
+            'price' => $eventDate->price,
+            'allowCancellation' => $eventDate->allowCancellation,
+            'enableWaitlist' => $eventDate->enableWaitlist,
+        ];
+    }
+
+    /**
+     * @param bool $redactPii Mask customer email/phone — set for bulk list output, where one
+     *                        call could otherwise exfiltrate the whole customer base.
+     * @return array<string, mixed>
+     */
+    public static function reservation(ReservationInterface $reservation, bool $redactPii = false): array
+    {
+        $email = $reservation->getUserEmail();
+        $phone = $reservation->getUserPhone();
+
+        return [
+            'id' => $reservation->getId(),
+            'uid' => $reservation->getUid(),
+            'status' => $reservation->getStatus(),
+            'serviceId' => $reservation->getServiceId(),
+            'employeeId' => $reservation->getEmployeeId(),
+            'locationId' => $reservation->getLocationId(),
+            'eventDateId' => $reservation->getEventDateId(),
+            'bookingDate' => $reservation->getBookingDate(),
+            'endDate' => $reservation->getEndDate(),
+            'startTime' => $reservation->getStartTime(),
+            'endTime' => $reservation->getEndTime(),
+            'isMultiDay' => $reservation->isMultiDay(),
+            'quantity' => $reservation->getQuantity(),
+            'userName' => $reservation->getUserName(),
+            'userEmail' => $redactPii ? PiiRedactor::redactEmail($email) : $email,
+            'userPhone' => $redactPii ? PiiRedactor::redactPhone($phone) : $phone,
+            'userTimezone' => $reservation->getUserTimezone(),
+            'notes' => $reservation->getNotes(),
+            'hasVirtualMeeting' => $reservation->getVirtualMeetingUrl() !== null,
+        ];
+        // NOTE: confirmationToken and virtualMeetingUrl are deliberately NOT exposed —
+        // both are bearer capabilities (the token authenticates the public
+        // cancel/reschedule endpoints; the URL is an unauthenticated meeting join link).
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function schedule(Schedule $schedule): array
+    {
+        return [
+            'id' => $schedule->id,
+            'title' => $schedule->title,
+            'enabled' => $schedule->enabled,
+            'workingHours' => $schedule->workingHours,
+            'startDate' => $schedule->startDate,
+            'endDate' => $schedule->endDate,
+            'sortOrder' => $schedule->sortOrder,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function blackoutDate(BlackoutDate $blackout): array
+    {
+        return [
+            'id' => $blackout->id,
+            'title' => $blackout->title,
+            'startDate' => $blackout->startDate,
+            'endDate' => $blackout->endDate,
+            'locationIds' => $blackout->locationIds,
+            'employeeIds' => $blackout->employeeIds,
+            'isActive' => $blackout->isActive,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function serviceExtra(ServiceExtra $extra): array
+    {
+        return [
+            'id' => $extra->id,
+            'title' => $extra->title,
+            'enabled' => $extra->enabled,
+            'description' => $extra->description,
+            'price' => $extra->price,
+            'duration' => $extra->duration,
+            'maxQuantity' => $extra->maxQuantity,
+            'isRequired' => $extra->isRequired,
+        ];
+    }
+
+    /**
+     * @param bool $redactPii Mask customer email/phone for bulk list output.
+     * @return array<string, mixed>
+     */
+    public static function waitlistEntry(WaitlistRecord $entry, bool $redactPii = false): array
+    {
+        return [
+            'id' => $entry->id,
+            'status' => $entry->status,
+            'serviceId' => $entry->serviceId,
+            'eventDateId' => $entry->eventDateId,
+            'employeeId' => $entry->employeeId,
+            'locationId' => $entry->locationId,
+            'preferredDate' => $entry->preferredDate,
+            'preferredTimeStart' => $entry->preferredTimeStart,
+            'preferredTimeEnd' => $entry->preferredTimeEnd,
+            'userName' => $entry->userName,
+            'userEmail' => $redactPii ? PiiRedactor::redactEmail($entry->userEmail) : $entry->userEmail,
+            'userPhone' => $redactPii ? PiiRedactor::redactPhone($entry->userPhone) : $entry->userPhone,
+            'priority' => $entry->priority,
+            'notifiedAt' => $entry->notifiedAt,
+            'expiresAt' => $entry->expiresAt,
+            'dateCreated' => $entry->dateCreated,
+        ];
+    }
+}

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -97,6 +97,8 @@ class Install extends Migration
                 'waitlistConversionMinutes' => $this->integer()->notNull()->defaultValue(30),
                 'mutexDriver' => $this->string(10)->notNull()->defaultValue('auto'),
                 'defaultTimeSlotLength' => $this->integer()->null(),
+                'mcpWriteEnabled' => $this->boolean()->notNull()->defaultValue(false),
+                'mcpAllowRefunds' => $this->boolean()->notNull()->defaultValue(false),
                 'dateCreated' => $this->dateTime()->notNull(),
                 'dateUpdated' => $this->dateTime()->notNull(),
                 'uid' => $this->uid(),

--- a/src/migrations/m260617_000000_add_mcp_settings.php
+++ b/src/migrations/m260617_000000_add_mcp_settings.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace anvildev\booked\migrations;
+
+use craft\db\Migration;
+
+/**
+ * Adds the default-off MCP authorization settings: writes (and, separately,
+ * refunds) over the MCP tool surface must be explicitly enabled by an admin.
+ */
+class m260617_000000_add_mcp_settings extends Migration
+{
+    public function safeUp(): bool
+    {
+        if (!$this->db->columnExists('{{%booked_settings}}', 'mcpWriteEnabled')) {
+            $this->addColumn('{{%booked_settings}}', 'mcpWriteEnabled', $this->boolean()->notNull()->defaultValue(false)->after('defaultTimeSlotLength'));
+        }
+        if (!$this->db->columnExists('{{%booked_settings}}', 'mcpAllowRefunds')) {
+            $this->addColumn('{{%booked_settings}}', 'mcpAllowRefunds', $this->boolean()->notNull()->defaultValue(false)->after('mcpWriteEnabled'));
+        }
+
+        return true;
+    }
+
+    public function safeDown(): bool
+    {
+        if ($this->db->columnExists('{{%booked_settings}}', 'mcpAllowRefunds')) {
+            $this->dropColumn('{{%booked_settings}}', 'mcpAllowRefunds');
+        }
+        if ($this->db->columnExists('{{%booked_settings}}', 'mcpWriteEnabled')) {
+            $this->dropColumn('{{%booked_settings}}', 'mcpWriteEnabled');
+        }
+
+        return true;
+    }
+}

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -116,6 +116,13 @@ class Settings extends Model
     public int $waitlistNotificationLimit = 10;
     public int $waitlistConversionMinutes = 30;
     public string $mutexDriver = 'auto';
+
+    // MCP (Model Context Protocol) — off by default; the AI tool surface can
+    // create/cancel/refund real bookings, so writes and refunds must be opted
+    // into explicitly by an administrator.
+    public bool $mcpWriteEnabled = false;
+    public bool $mcpAllowRefunds = false;
+
     // Frontend
     public ?int $defaultTimeSlotLength = null;
     public ?string $bookingPageUrl = null;
@@ -252,6 +259,7 @@ class Settings extends Model
             [['defaultTimeSlotLength'], 'integer', 'min' => 5],
             [['bookingPageUrl'], 'url', 'skipOnEmpty' => true],
             [['mutexDriver'], 'in', 'range' => ['auto', 'file', 'db', 'redis']],
+            [['mcpWriteEnabled', 'mcpAllowRefunds'], 'boolean'],
         ];
     }
 
@@ -352,6 +360,7 @@ class Settings extends Model
                 'enableHoneypot', 'honeypotFieldName',
                 'enableIpBlocking', 'blockedIps', 'enableTimeBasedLimits', 'minimumSubmissionTime',
                 'enableAuditLog',
+                'mcpWriteEnabled', 'mcpAllowRefunds',
             ],
             'calendar' => [
                 'googleCalendarEnabled', 'googleCalendarClientId', 'googleCalendarClientSecret',

--- a/src/services/EventDateService.php
+++ b/src/services/EventDateService.php
@@ -16,13 +16,19 @@ class EventDateService extends Component
     /**
      * @param int|string|null $siteId Site ID, '*' for all sites, or null for all sites (legacy default)
      */
-    public function getEventDates(?string $dateFrom = null, ?string $dateTo = null, int|string|null $siteId = '*'): array
+    public function getEventDates(?string $dateFrom = null, ?string $dateTo = null, int|string|null $siteId = '*', bool $enabledOnly = true): array
     {
         $query = EventDate::find()
             ->siteId($siteId)
             ->unique()
-            ->enabled(true)
             ->orderBy(['eventDate' => SORT_ASC, 'startTime' => SORT_ASC]);
+
+        if ($enabledOnly) {
+            $query->enabled(true);
+        } else {
+            // Include retired events so they can be found and re-enabled.
+            $query->status(null);
+        }
 
         if ($dateFrom) {
             $query->andWhere(['>=', 'booked_event_dates.eventDate', $dateFrom]);
@@ -47,9 +53,15 @@ class EventDateService extends Component
         ));
     }
 
-    public function getEventDateById(int $id): ?EventDate
+    public function getEventDateById(int $id, bool $includeDisabled = false): ?EventDate
     {
-        return EventDate::find()->siteId('*')->id($id)->one();
+        $query = EventDate::find()->siteId('*')->id($id);
+        if ($includeDisabled) {
+            // Admin/MCP management needs to resolve retired events too; booking
+            // flows keep the default enabled-only lookup.
+            $query->status(null);
+        }
+        return $query->one();
     }
 
     /** @throws \Exception */
@@ -60,18 +72,18 @@ class EventDateService extends Component
     }
 
     /** @throws \Exception */
-    public function updateEventDate(int $id, array $data): EventDate
+    public function updateEventDate(int $id, array $data, bool $includeDisabled = false): EventDate
     {
-        $event = $this->getEventDateById($id)
+        $event = $this->getEventDateById($id, $includeDisabled)
             ?? throw new \Exception("Event date with ID {$id} not found");
 
         return $this->saveEventDate($event, $data, 'update');
     }
 
     /** @throws \Exception */
-    public function deleteEventDate(int $id): bool
+    public function deleteEventDate(int $id, bool $includeDisabled = false): bool
     {
-        $event = $this->getEventDateById($id)
+        $event = $this->getEventDateById($id, $includeDisabled)
             ?? throw new \Exception("Event date with ID {$id} not found");
 
         $transaction = Craft::$app->getDb()->beginTransaction();

--- a/src/services/EventDateService.php
+++ b/src/services/EventDateService.php
@@ -3,6 +3,7 @@
 namespace anvildev\booked\services;
 
 use anvildev\booked\elements\EventDate;
+use anvildev\booked\exceptions\BookingConflictException;
 use anvildev\booked\factories\ReservationFactory;
 use anvildev\booked\helpers\DateHelper;
 use Craft;
@@ -16,7 +17,7 @@ class EventDateService extends Component
     /**
      * @param int|string|null $siteId Site ID, '*' for all sites, or null for all sites (legacy default)
      */
-    public function getEventDates(?string $dateFrom = null, ?string $dateTo = null, int|string|null $siteId = '*', bool $enabledOnly = true): array
+    public function getEventDates(?string $dateFrom = null, ?string $dateTo = null, int|string|null $siteId = '*', bool $enabledOnly = true, ?int $limit = null, ?int $offset = null): array
     {
         $query = EventDate::find()
             ->siteId($siteId)
@@ -35,6 +36,13 @@ class EventDateService extends Component
         }
         if ($dateTo) {
             $query->andWhere(['<=', 'booked_event_dates.eventDate', $dateTo]);
+        }
+
+        if ($limit !== null) {
+            $query->limit($limit);
+        }
+        if ($offset !== null) {
+            $query->offset($offset);
         }
 
         return $query->all();
@@ -97,7 +105,10 @@ class EventDateService extends Component
             $count = ReservationFactory::find()->eventDateId($id)->count();
             if ($count > 0) {
                 $transaction->rollBack();
-                throw new \Exception("Cannot delete event date: {$count} reservation(s) exist for this event");
+                // Typed (Booked) exception so the message survives the MCP guard()
+                // sanitiser — the caller needs the actionable "retire instead" reason,
+                // not a generic "internal error".
+                throw new BookingConflictException("Cannot delete event date: {$count} reservation(s) exist for this event. Retire it with enabled=false instead.");
             }
 
             $result = Craft::$app->elements->deleteElement($event);

--- a/src/services/RefundService.php
+++ b/src/services/RefundService.php
@@ -27,14 +27,26 @@ class RefundService extends Component
 
         $transactions = $order->getTransactions();
         $totalPaid = 0.0;
+        $totalRefunded = 0.0;
         foreach ($transactions as $transaction) {
-            if ($transaction->status === 'success' && $transaction->type !== 'refund') {
+            if ($transaction->status !== 'success') {
+                continue;
+            }
+            if ($transaction->type === 'refund') {
+                $totalRefunded += $transaction->paymentAmount;
+            } else {
                 $totalPaid += $transaction->paymentAmount;
             }
         }
 
+        // Idempotency guard: never refund more than what is still outstanding.
+        // Without this, a second call (or a call after a partial refund) would
+        // recompute the full paid amount — refund transactions are excluded from
+        // $totalPaid — and over-refund the customer.
+        $remaining = max(0.0, $totalPaid - $totalRefunded);
+
         $percentage = Booked::getInstance()->refundPolicy->calculateRefundPercentage($reservation);
-        $refundAmount = $totalPaid * ($percentage / 100);
+        $refundAmount = min($totalPaid * ($percentage / 100), $remaining);
         if ($refundAmount <= 0) {
             return true;
         }
@@ -72,9 +84,15 @@ class RefundService extends Component
         try {
             $transactions = $order->getTransactions();
             $successfulTransactions = [];
+            $alreadyRefunded = 0.0;
 
             foreach ($transactions as $transaction) {
-                if ($transaction->status === 'success' && $transaction->type !== 'refund') {
+                if ($transaction->status !== 'success') {
+                    continue;
+                }
+                if ($transaction->type === 'refund') {
+                    $alreadyRefunded += $transaction->paymentAmount;
+                } else {
                     $successfulTransactions[] = $transaction;
                 }
             }
@@ -84,12 +102,19 @@ class RefundService extends Component
                 return false;
             }
 
-            // Sum all successful non-refund transactions for the refund cap.
+            // Cap at what is still outstanding (paid minus already-refunded), so a
+            // repeat/partial-then-full sequence can never refund more than was paid.
             $totalPaid = array_sum(array_map(fn($t) => $t->paymentAmount, $successfulTransactions));
+            $remaining = max(0.0, $totalPaid - $alreadyRefunded);
 
-            if ($refundAmount > $totalPaid) {
-                Craft::warning("Refund amount ({$refundAmount}) exceeds total paid ({$totalPaid}) for order #{$order->id} — clamping to total paid", __METHOD__);
-                $refundAmount = $totalPaid;
+            if ($remaining <= 0) {
+                Craft::warning("Order #{$order->id} is already fully refunded — skipping refund", __METHOD__);
+                return true;
+            }
+
+            if ($refundAmount > $remaining) {
+                Craft::warning("Refund amount ({$refundAmount}) exceeds remaining refundable ({$remaining}) for order #{$order->id} — clamping", __METHOD__);
+                $refundAmount = $remaining;
             }
 
             // Use the most recent successful transaction for the gateway call,

--- a/src/services/ServiceExtraService.php
+++ b/src/services/ServiceExtraService.php
@@ -27,11 +27,17 @@ class ServiceExtraService extends Component
      *
      * @return ServiceExtra[]
      */
-    public function getAllExtras(bool $enabledOnly = false): array
+    public function getAllExtras(bool $enabledOnly = false, ?int $limit = null, ?int $offset = null): array
     {
         $query = ServiceExtra::find()->orderBy(['title' => SORT_ASC]);
         if ($enabledOnly) {
             $query->status('enabled');
+        }
+        if ($limit !== null) {
+            $query->limit($limit);
+        }
+        if ($offset !== null) {
+            $query->offset($offset);
         }
         return $query->all();
     }

--- a/src/services/WaitlistService.php
+++ b/src/services/WaitlistService.php
@@ -253,12 +253,20 @@ class WaitlistService extends Component
     }
 
     /** @return WaitlistRecord[] */
-    public function getActiveEntriesForService(int $serviceId): array
+    public function getActiveEntriesForService(int $serviceId, ?int $limit = null, ?int $offset = null): array
     {
-        return WaitlistRecord::find()
+        $query = WaitlistRecord::find()
             ->where(['serviceId' => $serviceId, 'status' => WaitlistRecord::STATUS_ACTIVE])
-            ->orderBy(['priority' => SORT_ASC, 'dateCreated' => SORT_ASC])
-            ->all();
+            ->orderBy(['priority' => SORT_ASC, 'dateCreated' => SORT_ASC]);
+
+        if ($limit !== null) {
+            $query->limit($limit);
+        }
+        if ($offset !== null) {
+            $query->offset($offset);
+        }
+
+        return $query->all();
     }
 
     public function isOnWaitlist(string $email, int $serviceId): bool

--- a/src/templates/settings/security.twig
+++ b/src/templates/settings/security.twig
@@ -239,5 +239,28 @@
             name: 'settings[enableAuditLog]',
             on: settings.enableAuditLog
         }) }}
+
+		<hr>
+
+		<h3>{{ 'settings.security.mcp'|t('booked') }}</h3>
+
+		{{ forms.lightswitchField({
+            label: 'settings.security.mcpWriteEnabled'|t('booked'),
+            instructions: 'settings.security.mcpWriteEnabledInstructions'|t('booked'),
+            id: 'mcpWriteEnabled',
+            name: 'settings[mcpWriteEnabled]',
+            on: settings.mcpWriteEnabled,
+            toggle: '#mcp-refund-settings'
+        }) }}
+
+		<div id="mcp-refund-settings" class="{% if not settings.mcpWriteEnabled %}hidden{% endif %}">
+			{{ forms.lightswitchField({
+                label: 'settings.security.mcpAllowRefunds'|t('booked'),
+                instructions: 'settings.security.mcpAllowRefundsInstructions'|t('booked'),
+                id: 'mcpAllowRefunds',
+                name: 'settings[mcpAllowRefunds]',
+                on: settings.mcpAllowRefunds
+            }) }}
+		</div>
 	</form>
 {% endblock %}

--- a/src/translations/en/booked.php
+++ b/src/translations/en/booked.php
@@ -1488,6 +1488,11 @@ return [
     'settings.security.auditLogging' => 'Audit Logging',
     'settings.security.enableAuditLog' => 'Enable Audit Log',
     'settings.security.enableAuditLogInstructions' => 'Log security-relevant events (cancellations, status changes, failed auth, rate limits, settings changes) to storage/logs/booked-audit.log in JSON-lines format.',
+    'settings.security.mcp' => 'AI / MCP Access',
+    'settings.security.mcpWriteEnabled' => 'Allow MCP write operations',
+    'settings.security.mcpWriteEnabledInstructions' => 'Let the AI/MCP tool surface create, edit, cancel and delete bookings, services, schedules and other records. Off by default — leave disabled unless an automated MCP client is explicitly trusted. Read-only tools are always available.',
+    'settings.security.mcpAllowRefunds' => 'Allow MCP refunds',
+    'settings.security.mcpAllowRefundsInstructions' => 'Additionally allow the MCP refund tool to issue real Commerce refunds. Requires "Allow MCP write operations" and the Commerce integration. Off by default.',
 
     // Settings - Commerce
     'settings.commerce.title' => 'Commerce Integration',

--- a/tests/Unit/Mcp/McpToolsTest.php
+++ b/tests/Unit/Mcp/McpToolsTest.php
@@ -297,6 +297,90 @@ class McpToolsTest extends TestCase
         );
     }
 
+    public function testGetReservationRedactsPii(): void
+    {
+        $src = file_get_contents(dirname(__DIR__, 3) . '/src/mcp/ReservationTools.php');
+
+        $this->assertMatchesRegularExpression(
+            '/getReservationById\(\$id\);.*?Presenter::reservation\(\$reservation,\s*redactPii:\s*true\)/s',
+            $src,
+            'booked_get_reservation must redact PII; ids are enumerable so an un-redacted get defeats list redaction.',
+        );
+    }
+
+    public function testListReservationsSingleBoundDateFilterUsesOperatorArray(): void
+    {
+        // The string form ">= {$date}" matches literally and finds nothing.
+        $src = file_get_contents(dirname(__DIR__, 3) . '/src/mcp/ReservationTools.php');
+
+        $this->assertStringContainsString("bookingDate(['>=', \$fromDate])", $src);
+        $this->assertStringContainsString("bookingDate(['<=', \$toDate])", $src);
+        $this->assertStringNotContainsString('bookingDate(">= {$fromDate}")', $src);
+        $this->assertStringNotContainsString('bookingDate("<= {$toDate}")', $src);
+    }
+
+    public function testUpdateReservationRejectsCancelStatus(): void
+    {
+        // status=cancelled here would skip the refund/capacity-release flow.
+        $src = file_get_contents(dirname(__DIR__, 3) . '/src/mcp/ReservationTools.php');
+
+        $this->assertStringContainsString("if (\$status === 'cancelled') {", $src);
+        $this->assertStringContainsString('booked_cancel_reservation', $src);
+    }
+
+    public function testListEventDatesIncludesDisabled(): void
+    {
+        // Admin assistant must see retired events to be able to re-enable them.
+        $src = file_get_contents(dirname(__DIR__, 3) . '/src/mcp/EventDateTools.php');
+
+        $this->assertStringContainsString('enabledOnly: false', $src);
+    }
+
+    public function testRevenueReportSummarisesReservationsAsCount(): void
+    {
+        // getRevenueData returns raw reservation models (for the CP view); over MCP
+        // those are opaque stubs + per-customer detail, so the tool must reduce them.
+        $src = file_get_contents(dirname(__DIR__, 3) . '/src/mcp/ReportTools.php');
+
+        $this->assertStringContainsString("\$revenue['reservationCount']", $src);
+        $this->assertStringContainsString("unset(\$revenue['reservations'])", $src);
+    }
+
+    public function testEventDateGetUpdateDeleteResolveDisabled(): void
+    {
+        // Listing disabled events is useless if get/update/delete can't then act
+        // on them (getEventDateById is enabled-only by default).
+        $src = file_get_contents(dirname(__DIR__, 3) . '/src/mcp/EventDateTools.php');
+
+        $this->assertSame(
+            3,
+            substr_count($src, 'includeDisabled: true'),
+            'get/update/delete event-date tools must resolve disabled events.',
+        );
+    }
+
+    public function testEmployeeServiceIdsAreValidated(): void
+    {
+        // serviceIds linking to bogus ids corrupts downstream availability/assignment.
+        $src = file_get_contents(dirname(__DIR__, 3) . '/src/mcp/CatalogTools.php');
+
+        $this->assertStringContainsString('unknownServiceIds', $src);
+        $this->assertSame(
+            2,
+            substr_count($src, '$this->unknownServiceIds('),
+            'Both createEmployee and updateEmployee must validate serviceIds.',
+        );
+    }
+
+    public function testRateLimiterUsesFixedWindowAndRecordsAfterSuccess(): void
+    {
+        $src = file_get_contents(dirname(__DIR__, 3) . '/src/mcp/ToolResponseTrait.php');
+
+        // Pinned expiry = fixed window (no TTL reset); mutex = atomic increment.
+        $this->assertStringContainsString("'expiresAt'", $src);
+        $this->assertStringContainsString('getMutex()', $src);
+    }
+
     public function testGuardSanitisesNonBookedExceptionMessages(): void
     {
         $src = file_get_contents(dirname(__DIR__, 3) . '/src/mcp/ToolResponseTrait.php');
@@ -306,7 +390,8 @@ class McpToolsTest extends TestCase
             $src,
             'guard() must only pass through messages from Booked\'s own exceptions; others leak DB/internal detail.',
         );
-        $this->assertStringContainsString('withinRateLimit', $src, 'A notification rate-limit helper must exist.');
+        $this->assertStringContainsString('rateLimitReached', $src, 'A rate-limit check helper must exist.');
+        $this->assertStringContainsString('recordRateLimitedCall', $src, 'A rate-limit record helper must exist.');
     }
 
     public function testNotificationToolsAreRateLimited(): void
@@ -314,9 +399,10 @@ class McpToolsTest extends TestCase
         $resv = file_get_contents(dirname(__DIR__, 3) . '/src/mcp/ReservationTools.php');
         $wait = file_get_contents(dirname(__DIR__, 3) . '/src/mcp/WaitlistTools.php');
 
-        // create + cancel (reservations) and add x2 + notify (waitlist) must all be throttled.
-        $this->assertGreaterThanOrEqual(3, substr_count($resv, "withinRateLimit('notify'"));
-        $this->assertGreaterThanOrEqual(3, substr_count($wait, "withinRateLimit('notify'"));
+        // All side-effecting reservation writes (create/cancel/update/quantity/refund)
+        // and the three notifying waitlist tools (add x2 + notify) must be throttled.
+        $this->assertGreaterThanOrEqual(3, substr_count($resv, 'rateLimitReached('));
+        $this->assertGreaterThanOrEqual(3, substr_count($wait, 'rateLimitReached('));
     }
 
     public function testEmployeeToolsDoNotAcceptUserId(): void

--- a/tests/Unit/Mcp/McpToolsTest.php
+++ b/tests/Unit/Mcp/McpToolsTest.php
@@ -1,0 +1,348 @@
+<?php
+
+namespace anvildev\booked\tests\Unit\Mcp;
+
+use anvildev\booked\mcp\AvailabilityTools;
+use anvildev\booked\mcp\BlackoutDateTools;
+use anvildev\booked\mcp\CatalogTools;
+use anvildev\booked\mcp\EventDateTools;
+use anvildev\booked\mcp\ReportTools;
+use anvildev\booked\mcp\ReservationTools;
+use anvildev\booked\mcp\ScheduleTools;
+use anvildev\booked\mcp\ServiceExtraTools;
+use anvildev\booked\mcp\ToolResponseTrait;
+use anvildev\booked\mcp\WaitlistTools;
+use anvildev\booked\tests\Support\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+
+/**
+ * Verifies Booked's craft-mcp integration: the tool classes declare the
+ * expected `#[McpTool]` set, write tools are flagged dangerous, and Booked.php
+ * wires registration through the (guarded) EVENT_REGISTER_TOOLS event.
+ *
+ * The assertions read attribute arguments reflectively via
+ * {@see \ReflectionAttribute::getArguments()}, which never instantiates the
+ * attribute classes — so the suite passes whether or not the optional
+ * stimmt/craft-mcp package is installed.
+ */
+class McpToolsTest extends TestCase
+{
+    private const MCP_TOOL_ATTR = 'Mcp\\Capability\\Attribute\\McpTool';
+    private const MCP_META_ATTR = 'stimmt\\craft\\Mcp\\attributes\\McpToolMeta';
+
+    /** @var array<class-string, list<string>> */
+    private const EXPECTED_TOOLS = [
+        CatalogTools::class => [
+            'booked_list_services',
+            'booked_get_service',
+            'booked_create_service',
+            'booked_list_employees',
+            'booked_list_locations',
+            'booked_update_service',
+            'booked_get_location',
+            'booked_create_location',
+            'booked_update_location',
+            'booked_get_employee',
+            'booked_create_employee',
+            'booked_update_employee',
+        ],
+        AvailabilityTools::class => [
+            'booked_check_availability',
+            'booked_next_available_date',
+            'booked_availability_summary',
+        ],
+        ReservationTools::class => [
+            'booked_list_reservations',
+            'booked_get_reservation',
+            'booked_booking_stats',
+            'booked_create_booking',
+            'booked_create_event_booking',
+            'booked_cancel_reservation',
+            'booked_update_reservation',
+            'booked_reduce_reservation_quantity',
+            'booked_increase_reservation_quantity',
+            'booked_refund_reservation',
+        ],
+        EventDateTools::class => [
+            'booked_list_event_dates',
+            'booked_get_event_date',
+            'booked_create_event_date',
+            'booked_update_event_date',
+            'booked_delete_event_date',
+        ],
+        ScheduleTools::class => [
+            'booked_list_schedules',
+            'booked_get_schedule',
+            'booked_create_schedule',
+            'booked_update_schedule',
+            'booked_get_employee_schedules',
+            'booked_set_employee_schedules',
+        ],
+        BlackoutDateTools::class => [
+            'booked_list_blackout_dates',
+            'booked_create_blackout_date',
+            'booked_set_blackout_date_active',
+            'booked_check_date_blacked_out',
+        ],
+        ServiceExtraTools::class => [
+            'booked_list_service_extras',
+            'booked_create_service_extra',
+            'booked_get_service_extras',
+            'booked_set_service_extras',
+            'booked_get_service_locations',
+            'booked_set_service_locations',
+        ],
+        ReportTools::class => [
+            'booked_revenue_report',
+            'booked_bookings_by_service',
+            'booked_bookings_by_employee',
+            'booked_bookings_by_location',
+            'booked_cancellation_report',
+            'booked_peak_hours_report',
+            'booked_utilization_report',
+            'booked_dashboard_summary',
+        ],
+        WaitlistTools::class => [
+            'booked_list_waitlist',
+            'booked_waitlist_stats',
+            'booked_add_to_waitlist',
+            'booked_add_to_event_waitlist',
+            'booked_cancel_waitlist_entry',
+            'booked_notify_waitlist_entry',
+        ],
+    ];
+
+    /** @var list<string> Tools that mutate data and must be flagged dangerous. */
+    private const DANGEROUS_TOOLS = [
+        'booked_create_service',
+        'booked_update_service',
+        'booked_create_location',
+        'booked_update_location',
+        'booked_create_employee',
+        'booked_update_employee',
+        'booked_create_booking',
+        'booked_create_event_booking',
+        'booked_cancel_reservation',
+        'booked_update_reservation',
+        'booked_reduce_reservation_quantity',
+        'booked_increase_reservation_quantity',
+        'booked_refund_reservation',
+        'booked_create_event_date',
+        'booked_update_event_date',
+        'booked_delete_event_date',
+        'booked_create_schedule',
+        'booked_update_schedule',
+        'booked_set_employee_schedules',
+        'booked_create_blackout_date',
+        'booked_set_blackout_date_active',
+        'booked_create_service_extra',
+        'booked_set_service_extras',
+        'booked_set_service_locations',
+        'booked_add_to_waitlist',
+        'booked_add_to_event_waitlist',
+        'booked_cancel_waitlist_entry',
+        'booked_notify_waitlist_entry',
+    ];
+
+    /**
+     * @dataProvider toolClassProvider
+     * @param class-string $class
+     */
+    public function testToolClassUsesResponseTrait(string $class): void
+    {
+        $this->assertContains(
+            ToolResponseTrait::class,
+            $this->traitNames($class),
+            "{$class} should use ToolResponseTrait for uniform error handling",
+        );
+    }
+
+    /**
+     * @dataProvider toolClassProvider
+     * @param class-string $class
+     * @param list<string> $expectedNames
+     */
+    public function testToolClassDeclaresExpectedTools(string $class, array $expectedNames): void
+    {
+        $declared = $this->declaredToolNames($class);
+        sort($declared);
+        sort($expectedNames);
+
+        $this->assertSame(
+            $expectedNames,
+            $declared,
+            "{$class} should declare exactly the expected #[McpTool] names",
+        );
+    }
+
+    public function testToolNamesAreGloballyUnique(): void
+    {
+        $all = [];
+        foreach (array_keys(self::EXPECTED_TOOLS) as $class) {
+            $all = array_merge($all, $this->declaredToolNames($class));
+        }
+
+        $this->assertSame(
+            array_values(array_unique($all)),
+            $all,
+            'MCP tool names must be unique across all Booked tool classes',
+        );
+    }
+
+    public function testWriteToolsAreFlaggedDangerous(): void
+    {
+        // The dangerous flag is read from source rather than via
+        // ReflectionAttribute::getArguments(), because evaluating the McpToolMeta
+        // arguments would resolve the `ToolCategory` enum that ships with the
+        // (optional, here-absent) craft-mcp package.
+        $dangerous = [];
+        foreach (self::EXPECTED_TOOLS as $class => $names) {
+            $source = file_get_contents((new ReflectionClass($class))->getFileName());
+            foreach ($names as $tool) {
+                if ($this->methodIsFlaggedDangerous($source, $tool)) {
+                    $dangerous[] = $tool;
+                }
+            }
+        }
+
+        sort($dangerous);
+        $expected = self::DANGEROUS_TOOLS;
+        sort($expected);
+
+        $this->assertSame(
+            $expected,
+            $dangerous,
+            'Exactly the data-mutating tools must carry #[McpToolMeta(dangerous: true)]',
+        );
+    }
+
+    /**
+     * Whether the tool whose #[McpTool(name: $tool)] is declared in $source is
+     * flagged dangerous, by inspecting the attribute block up to its method body.
+     */
+    private function methodIsFlaggedDangerous(string $source, string $tool): bool
+    {
+        $start = strpos($source, "name: '{$tool}'");
+        if ($start === false) {
+            return false;
+        }
+        $end = strpos($source, 'public function', $start);
+        $block = substr($source, $start, $end === false ? null : $end - $start);
+
+        return str_contains($block, 'dangerous: true');
+    }
+
+    public function testEveryToolAlsoDeclaresMetaCategory(): void
+    {
+        foreach (array_keys(self::EXPECTED_TOOLS) as $class) {
+            foreach ((new ReflectionClass($class))->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+                if ($this->toolName($method) === null) {
+                    continue;
+                }
+                $this->assertNotEmpty(
+                    $method->getAttributes(self::MCP_META_ATTR),
+                    "{$class}::{$method->getName()} should also carry #[McpToolMeta]",
+                );
+            }
+        }
+    }
+
+    public function testBookedRegistersToolsGuardedByClassExists(): void
+    {
+        $source = file_get_contents(dirname(__DIR__, 3) . '/src/Booked.php');
+
+        $this->assertStringContainsString('registerMcpTools', $source);
+        $this->assertStringContainsString('class_exists(\\stimmt\\craft\\Mcp\\Mcp::class)', $source);
+        $this->assertStringContainsString('\\stimmt\\craft\\Mcp\\Mcp::EVENT_REGISTER_TOOLS', $source);
+
+        foreach (array_keys(self::EXPECTED_TOOLS) as $class) {
+            $this->assertStringContainsString(
+                "\$event->addTool(\\{$class}::class, 'booked')",
+                $source,
+                "Booked.php should register {$class} with the 'booked' source",
+            );
+        }
+    }
+
+    public function testReservationPresenterHidesCapabilityTokens(): void
+    {
+        $src = file_get_contents(dirname(__DIR__, 3) . '/src/mcp/support/Presenter.php');
+
+        $this->assertStringNotContainsString(
+            "'confirmationToken' =>",
+            $src,
+            'confirmationToken must never be serialised over MCP — it authenticates the public cancel/reschedule endpoints.',
+        );
+        $this->assertStringNotContainsString(
+            "'virtualMeetingUrl' =>",
+            $src,
+            'virtualMeetingUrl must never be serialised over MCP — it is an unauthenticated meeting join link.',
+        );
+    }
+
+    public function testBulkListToolsRedactCustomerPii(): void
+    {
+        $base = dirname(__DIR__, 3) . '/src/mcp';
+
+        $this->assertStringContainsString(
+            'redactPii: true',
+            file_get_contents($base . '/ReservationTools.php'),
+            'booked_list_reservations must redact PII so one call cannot exfiltrate the customer base.',
+        );
+        $this->assertStringContainsString(
+            'redactPii: true',
+            file_get_contents($base . '/WaitlistTools.php'),
+            'booked_list_waitlist must redact PII in bulk output.',
+        );
+    }
+
+    /**
+     * @return array<string, array{class-string, list<string>}>
+     */
+    public static function toolClassProvider(): array
+    {
+        $cases = [];
+        foreach (self::EXPECTED_TOOLS as $class => $names) {
+            $cases[$class] = [$class, $names];
+        }
+        return $cases;
+    }
+
+    /**
+     * @param class-string $class
+     * @return list<string>
+     */
+    private function declaredToolNames(string $class): array
+    {
+        $names = [];
+        foreach ((new ReflectionClass($class))->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+            $name = $this->toolName($method);
+            if ($name !== null) {
+                $names[] = $name;
+            }
+        }
+        return $names;
+    }
+
+    private function toolName(ReflectionMethod $method): ?string
+    {
+        $attr = $method->getAttributes(self::MCP_TOOL_ATTR)[0] ?? null;
+        return $attr?->getArguments()['name'] ?? null;
+    }
+
+    /**
+     * @param class-string $class
+     * @return list<string>
+     */
+    private function traitNames(string $class): array
+    {
+        $names = [];
+        $ref = new ReflectionClass($class);
+        while ($ref) {
+            $names = array_merge($names, array_keys($ref->getTraits()));
+            $ref = $ref->getParentClass();
+        }
+        return $names;
+    }
+}

--- a/tests/Unit/Mcp/McpToolsTest.php
+++ b/tests/Unit/Mcp/McpToolsTest.php
@@ -423,6 +423,122 @@ class McpToolsTest extends TestCase
         $this->assertStringContainsString('instanceof \\stdClass', $src, 'Only plain stdClass should be expanded via get_object_vars.');
     }
 
+    public function testMutatingToolsRouteThroughWriteAuthorization(): void
+    {
+        // Every tool flagged `dangerous: true` must run behind guardWrite() (the
+        // write-authorization gate), and read tools must NOT — so the count of
+        // guardWrite() calls in each class equals its count of dangerous tools.
+        $base = dirname(__DIR__, 3) . '/src/mcp';
+        foreach ([
+            'CatalogTools.php',
+            'ReservationTools.php',
+            'EventDateTools.php',
+            'ScheduleTools.php',
+            'BlackoutDateTools.php',
+            'ServiceExtraTools.php',
+            'WaitlistTools.php',
+        ] as $file) {
+            $src = file_get_contents($base . '/' . $file);
+            $this->assertSame(
+                substr_count($src, 'dangerous: true'),
+                substr_count($src, '$this->guardWrite('),
+                "{$file}: every dangerous tool must use guardWrite() and no read tool may.",
+            );
+        }
+    }
+
+    public function testWriteAuthorizationGateIsDefaultDeny(): void
+    {
+        $src = file_get_contents(dirname(__DIR__, 3) . '/src/mcp/ToolResponseTrait.php');
+
+        $this->assertStringContainsString('function guardWrite(', $src, 'A write-authorization wrapper must exist.');
+        $this->assertStringContainsString('mcpWriteEnabled', $src, 'Writes must be gated by the default-off mcpWriteEnabled setting.');
+        $this->assertStringContainsString(
+            "can('booked-manageBookings')",
+            $src,
+            'In a web context the CP permission must be enforced as defense in depth.',
+        );
+    }
+
+    public function testRefundRequiresExplicitOptIn(): void
+    {
+        $src = file_get_contents(dirname(__DIR__, 3) . '/src/mcp/ReservationTools.php');
+
+        // Refunds move money, so they need their own opt-in on top of the write gate.
+        $this->assertStringContainsString('mcpAllowRefunds', $src, 'refund_reservation must check the dedicated mcpAllowRefunds setting.');
+    }
+
+    public function testMcpWriteSettingsDefaultOff(): void
+    {
+        $src = file_get_contents(dirname(__DIR__, 3) . '/src/models/Settings.php');
+
+        $this->assertMatchesRegularExpression('/public bool \$mcpWriteEnabled = false;/', $src);
+        $this->assertMatchesRegularExpression('/public bool \$mcpAllowRefunds = false;/', $src);
+    }
+
+    public function testRefundServiceCapsAtRemainingRefundable(): void
+    {
+        // Without an idempotency guard, a repeat (or partial-then-full) refund
+        // recomputes the full paid amount and over-refunds the customer.
+        $src = file_get_contents(dirname(__DIR__, 3) . '/src/services/RefundService.php');
+
+        $this->assertStringContainsString("\$transaction->type === 'refund'", $src, 'Prior refunds must be summed, not ignored.');
+        $this->assertStringContainsString('$remaining', $src, 'Refund must be capped at the outstanding (paid minus already-refunded) amount.');
+    }
+
+    public function testPresenterRedactsPiiByDefault(): void
+    {
+        $src = file_get_contents(dirname(__DIR__, 3) . '/src/mcp/support/Presenter.php');
+
+        // Fail-safe default: a new caller that forgets the flag still redacts.
+        $this->assertStringContainsString('ReservationInterface $reservation, bool $redactPii = true', $src);
+        $this->assertStringContainsString('WaitlistRecord $entry, bool $redactPii = true', $src);
+    }
+
+    public function testListToolsClampPageSize(): void
+    {
+        $trait = file_get_contents(dirname(__DIR__, 3) . '/src/mcp/ToolResponseTrait.php');
+        $this->assertStringContainsString('LIST_LIMIT_MAX', $trait, 'A hard page-size ceiling must exist.');
+        $this->assertStringContainsString('function clampLimit(', $trait);
+
+        // Every list tool must clamp its caller-supplied limit (no unbounded ->all()).
+        $base = dirname(__DIR__, 3) . '/src/mcp';
+        foreach ([
+            'CatalogTools.php',
+            'ReservationTools.php',
+            'ScheduleTools.php',
+            'BlackoutDateTools.php',
+            'EventDateTools.php',
+            'ServiceExtraTools.php',
+            'WaitlistTools.php',
+        ] as $file) {
+            $this->assertStringContainsString(
+                'clampLimit(',
+                file_get_contents($base . '/' . $file),
+                "{$file}: list tools must clamp the page size.",
+            );
+        }
+    }
+
+    public function testDeleteEventDateConflictUsesBookedException(): void
+    {
+        // delete_event_date on an event with reservations must refuse with a
+        // Booked typed exception so guard() surfaces the actionable "retire
+        // instead" message rather than masking it as a generic internal error.
+        $src = file_get_contents(dirname(__DIR__, 3) . '/src/services/EventDateService.php');
+
+        $this->assertMatchesRegularExpression(
+            '/throw new BookingConflictException\([^)]*reservation\(s\) exist/',
+            $src,
+            'The "reservations exist" delete refusal must throw a Booked exception, not a plain \\Exception.',
+        );
+        $this->assertStringNotContainsString(
+            'throw new \\Exception("Cannot delete event date',
+            $src,
+            'The delete-conflict path must no longer throw a plain \\Exception (guard() would mask it).',
+        );
+    }
+
     /**
      * @return array<string, array{class-string, list<string>}>
      */

--- a/tests/Unit/Mcp/McpToolsTest.php
+++ b/tests/Unit/Mcp/McpToolsTest.php
@@ -297,6 +297,46 @@ class McpToolsTest extends TestCase
         );
     }
 
+    public function testGuardSanitisesNonBookedExceptionMessages(): void
+    {
+        $src = file_get_contents(dirname(__DIR__, 3) . '/src/mcp/ToolResponseTrait.php');
+
+        $this->assertStringContainsString(
+            "str_starts_with(\$e::class, 'anvildev\\\\booked\\\\exceptions\\\\')",
+            $src,
+            'guard() must only pass through messages from Booked\'s own exceptions; others leak DB/internal detail.',
+        );
+        $this->assertStringContainsString('withinRateLimit', $src, 'A notification rate-limit helper must exist.');
+    }
+
+    public function testNotificationToolsAreRateLimited(): void
+    {
+        $resv = file_get_contents(dirname(__DIR__, 3) . '/src/mcp/ReservationTools.php');
+        $wait = file_get_contents(dirname(__DIR__, 3) . '/src/mcp/WaitlistTools.php');
+
+        // create + cancel (reservations) and add x2 + notify (waitlist) must all be throttled.
+        $this->assertGreaterThanOrEqual(3, substr_count($resv, "withinRateLimit('notify'"));
+        $this->assertGreaterThanOrEqual(3, substr_count($wait, "withinRateLimit('notify'"));
+    }
+
+    public function testEmployeeToolsDoNotAcceptUserId(): void
+    {
+        $src = file_get_contents(dirname(__DIR__, 3) . '/src/mcp/CatalogTools.php');
+
+        // userId controls CP booking visibility — it must not be client-settable over MCP.
+        $this->assertStringNotContainsString('$userId', $src, 'create/update_employee must not expose a userId param.');
+        $this->assertStringNotContainsString('->userId =', $src, 'Employee.userId must not be written from MCP input.');
+    }
+
+    public function testJsonSafeGuardsRecursionAndDoesNotDumpArbitraryObjects(): void
+    {
+        $src = file_get_contents(dirname(__DIR__, 3) . '/src/mcp/support/Presenter.php');
+
+        $this->assertStringContainsString('$depth', $src, 'jsonSafe must carry a recursion-depth guard.');
+        $this->assertStringContainsString("'_class' =>", $src, 'Unknown objects must collapse to an opaque class stub, not their internals.');
+        $this->assertStringContainsString('instanceof \\stdClass', $src, 'Only plain stdClass should be expanded via get_object_vars.');
+    }
+
     /**
      * @return array<string, array{class-string, list<string>}>
      */

--- a/tests/Unit/Services/EventDateServiceTest.php
+++ b/tests/Unit/Services/EventDateServiceTest.php
@@ -86,7 +86,7 @@ class EventDateServiceTest extends TestCase
     public function testUpdateEventDateThrowsWhenEventNotFound(): void
     {
         $service = $this->makePartialService();
-        $service->shouldReceive('getEventDateById')->with(999)->andReturn(null);
+        $service->shouldReceive('getEventDateById')->with(999, false)->andReturn(null);
 
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Event date with ID 999 not found');
@@ -101,7 +101,7 @@ class EventDateServiceTest extends TestCase
     public function testDeleteEventDateThrowsWhenEventNotFound(): void
     {
         $service = $this->makePartialService();
-        $service->shouldReceive('getEventDateById')->with(999)->andReturn(null);
+        $service->shouldReceive('getEventDateById')->with(999, false)->andReturn(null);
 
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Event date with ID 999 not found');


### PR DESCRIPTION
## Summary

Adds an optional **MCP (Model Context Protocol)** integration that exposes Booked to AI assistants (Claude, Cursor, …) via the [craft-mcp](https://github.com/stimmtdigital/craft-mcp) plugin — ~50 tools covering near-complete headless administration.

The dependency is **soft**: registration is `class_exists()`-guarded and craft-mcp is declared only under composer `suggest`, so Booked runs unchanged when it isn't installed.

### Tools (`src/mcp/`)
- **Catalog** — services / employees / locations: list, get, create, update (soft-disable via `enabled`; no hard delete)
- **Availability** — slot availability, next-available-date, range summary
- **Reservations** — list/get, stats, create (slot + event), reschedule/edit, quantity ±, cancel, refund
- **Event dates** — list/get/create/update + guarded delete (refuses if reservations exist)
- **Schedules** — CRUD + employee assignment
- **Blackout dates** — list/create + active-toggle + date check
- **Service extras & links** — extras CRUD + service↔extra / service↔location assignment
- **Reports** — revenue, by service/employee/location, cancellation, peak hours, utilization, dashboard
- **Waitlist** — list, stats, add (service/event), cancel, notify

All writes route through Booked's existing services (`BookingService`, `EventDateService`, …), so validation, slot-locking, notifications and webhooks behave exactly as in the Control Panel.

### Security
This surface was security-reviewed before opening:
- **Booking capability tokens are never exposed** — `confirmationToken` (the sole auth for the public cancel/reschedule endpoints) and `virtualMeetingUrl` are not serialised; tools return only a `hasVirtualMeeting` boolean.
- **Customer PII is redacted in bulk output** — `booked_list_reservations` / `booked_list_waitlist` mask email/phone via the plugin's `PiiRedactor`; single-record `get` returns full detail.
- All mutating tools are flagged `#[McpToolMeta(dangerous: true)]` so clients can require confirmation.
- **Note:** the MCP server itself is the trust boundary (no per-tool permission layer, by design) — gate it with craft-mcp's `allowedIps` / `enableDangerousTools` settings.

### Testing
- `McpToolsTest` covers every declared tool, the dangerous-flag set, and the token/PII guards.
- ECS + PHPStan clean; full plugin suite green.
- Verified **end-to-end** against craft-mcp v1.2.2 (mcp/sdk 0.4) over the live stdio MCP server — every tool exercised, including create/cancel/refund, reports, and error paths.

See [MCP.md](MCP.md) for setup and the full tool reference.
