### PR TITLE
Add guardrailed Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+
+updates:
+  # Composer dependencies — guardrailed for a *library*, where wide version
+  # ranges are intentional and the toolchain is deliberately pinned.
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - composer
+    commit-message:
+      prefix: chore
+      prefix-development: chore
+    # One rollup PR for the dev toolchain instead of one PR per package.
+    groups:
+      dev-dependencies:
+        dependency-type: development
+    ignore:
+      # We support the whole ^5.0 range on purpose; don't narrow the floor.
+      - dependency-name: "craftcms/cms"
+      # phpstan/phpstan is capped at ^1.x by craftcms/phpstan (dev-main);
+      # a major bump would break the quality gate. Allow patch/minor only.
+      - dependency-name: "phpstan/phpstan"
+        update-types:
+          - version-update:semver-major


### PR DESCRIPTION
Enables Dependabot for this plugin, mirroring the guardrailed config trialed on Beacon (PR #19).

## What it does
- **Composer** — weekly, scoped for a *library*:
  - Dev toolchain grouped into a single rollup PR instead of one PR per package.
  - `craftcms/cms` version updates ignored — we support the whole range on purpose.
  - `phpstan/phpstan` capped at v1 (major bumps ignored) since `craftcms/phpstan` pins it there.

## Notes
- `craftcms/phpstan` / `craftcms/ecs` / `craftcms/rector` track `dev-main`, so Dependabot wont raise version PRs for them.
- Takes effect once merged to `main`. Security alerts/updates are a separate repo toggle (admin).