### PR TITLE
Clarify legacy-wizard deprecation notice + reword stale Alpine docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+- The legacy-wizard deprecation notice now reads "deprecated as of Booked 1.3 and will be removed in 2.0" for clarity. Internal design docs reworded to past tense now that the vanilla wizard is the default.
+
 ## 1.3.0 - 2026-07-26
 
 > `{% include 'booked/frontend/wizard' %}` now renders the framework-free vanilla wizard **by default** — no template changes needed. The deprecated Alpine wizard is available for one release window via the **`legacyWizard`** setting (or `{% include … with { legacyWizard: true } %}`), logged as deprecated, and removed in 2.0.

--- a/docs/WIZARD_CORE_DESIGN.md
+++ b/docs/WIZARD_CORE_DESIGN.md
@@ -13,7 +13,7 @@ This design covers **both** the booking flow and the event flow (plus event-mana
 The core is the semver'd, zero-dependency brain that any frontend drives:
 
 1. **Zero runtime dependencies**, no `eval`/`new Function`, no DOM assumptions. Runs headless (Node/tests) or behind any renderer.
-2. **Explicit, testable state machine** — replaces today's implicit Alpine reactive state and the hand-written `nextStep` / `getPreviousStep` / `shouldSkipEmployeeStep` split that is the source of back-nav and lock-expiry edge-case bugs.
+2. **Explicit, testable state machine** — replaces the previous Alpine implementation's implicit reactive state and the hand-written `nextStep` / `getPreviousStep` / `shouldSkipEmployeeStep` split that was the source of back-nav and lock-expiry edge-case bugs.
 3. **One flow engine, two flows** — booking and event flows are *data* (step definitions + endpoint bindings), not forked code.
 4. **Events over overrides** — every meaningful transition emits; the renderer is just the first consumer, which proves the headless contract.
 5. **First-class soft-lock with a hold timer** — the current wizard has *no* client-side countdown and only discovers an expired lock at submit. The core owns the timer and emits `lock:expiring` / `lock:expired`.
@@ -55,7 +55,7 @@ Budget: core + UI gzipped **< 25 KB** (PRD success metric). Core alone is expect
 
 ## 3. The state machine
 
-Two dimensions kept deliberately separate — conflating them is what makes the Alpine version fragile:
+Two dimensions kept deliberately separate — conflating them is what made the previous Alpine version fragile:
 
 - **Lifecycle state** — *what phase the booking is in* (finite, guarded).
 - **Step cursor** — *which visible step the user is on* within the browsing phase (derived from the flow definition, never hand-maintained).

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -60,7 +60,7 @@ class Settings extends Model
     // Frontend wizard
     /**
      * Restore the legacy Alpine.js booking wizard instead of the framework-free
-     * vanilla wizard. Deprecated — this escape hatch is removed in Booked 2.0.
+     * vanilla wizard. Deprecated as of 1.3 — this escape hatch is removed in Booked 2.0.
      */
     public bool $legacyWizard = false;
 

--- a/src/variables/BookingVariable.php
+++ b/src/variables/BookingVariable.php
@@ -170,7 +170,7 @@ class BookingVariable
     {
         Craft::$app->getDeprecator()->log(
             'booked-legacy-wizard',
-            'The Alpine.js Booked wizard is deprecated and will be removed in Booked 2.0. Unset the "legacyWizard" setting to use the framework-free vanilla wizard.',
+            'The Alpine.js Booked wizard is deprecated as of Booked 1.3 and will be removed in 2.0. Unset the "legacyWizard" setting to use the framework-free vanilla wizard.',
         );
 
         return '';


### PR DESCRIPTION
Post-1.3 copy fixes (next release):

- Deprecation notice now reads **"deprecated as of Booked 1.3 and will be removed in 2.0"** (was just "removed in 2.0") — makes the deprecation-since version explicit. Removal target stays 2.0 (removing the wizard is a breaking change → major version).
- `Settings::legacyWizard` docstring aligned ("Deprecated as of 1.3").
- `WIZARD_CORE_DESIGN.md`: reworded now-stale present-tense "today's Alpine" language to past tense, since the vanilla wizard is now the default.

Deliberately **kept** (still needed until 2.0): the legacy Alpine JS + `*-alpine.twig` templates and the `legacyWizard` fallback, the "Migrating from the Alpine wizard" guide in VANILLA_WIZARD.md, and the CHANGELOG history.

No behavior change; ECS clean, no tests affected.