### PR TITLE
[M2] Policy-aware direct-payment refund service (#37)

### DIFF
--- a/src/events/PaymentRefundedEvent.php
+++ b/src/events/PaymentRefundedEvent.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace anvildev\booked\events;
+
+use anvildev\booked\records\PaymentRecord;
+use yii\base\Event;
+
+/**
+ * Raised after a direct (Commerce-free) payment is successfully refunded, in
+ * full or in part. Amounts are in the currency's minor units, matching
+ * {@see PaymentRecord}. The Commerce-mode failure counterpart is
+ * {@see RefundFailedEvent}.
+ */
+class PaymentRefundedEvent extends Event
+{
+    public int $reservationId;
+    public PaymentRecord $record;
+
+    /** The amount refunded by this operation, in minor units. */
+    public int $amount;
+
+    /** The record's cumulative refunded total after this operation, in minor units. */
+    public int $totalRefunded;
+}

--- a/src/services/PaymentService.php
+++ b/src/services/PaymentService.php
@@ -5,13 +5,16 @@ namespace anvildev\booked\services;
 use anvildev\booked\Booked;
 use anvildev\booked\contracts\PaymentGatewayInterface;
 use anvildev\booked\contracts\ReservationInterface;
+use anvildev\booked\events\PaymentRefundedEvent;
 use anvildev\booked\helpers\PaymentTokenHelper;
 use anvildev\booked\models\Settings;
 use anvildev\booked\payments\PaymentContext;
+use anvildev\booked\payments\RefundResult;
 use anvildev\booked\records\PaymentRecord;
 use Craft;
 use craft\base\Component;
 use craft\helpers\App;
+use RuntimeException;
 
 /**
  * Orchestrates native (direct) payments: create a gateway payment for a
@@ -21,6 +24,12 @@ use craft\helpers\App;
  */
 class PaymentService extends Component
 {
+    /**
+     * Raised after a direct payment is successfully refunded (full or partial).
+     * @event PaymentRefundedEvent
+     */
+    public const EVENT_PAYMENT_REFUNDED = 'paymentRefunded';
+
     /**
      * Create a payment for a reservation through the given gateway. Persists a
      * pending {@see PaymentRecord} and returns it plus the gateway session and a
@@ -96,6 +105,76 @@ class PaymentService extends Component
             PaymentRecord::STATUS_REFUNDED,
             PaymentRecord::STATUS_PARTIALLY_REFUNDED,
         ], true);
+    }
+
+    /**
+     * Refund a direct (Commerce-free) payment, honoring the reservation's refund
+     * policy. `$amount` is in the currency's minor units; `null` refunds the
+     * maximum the policy currently allows (capped at the remaining refundable).
+     *
+     * The refund policy is a hard ceiling: an explicit amount above it — or above
+     * what's still refundable — is rejected *before* any gateway call, so the
+     * customer is never over-refunded. Idempotent by construction: each call only
+     * ever adds up to the remaining refundable, and a fully-refunded payment
+     * refuses further refunds.
+     *
+     * On a gateway failure the record is left untouched and the failed
+     * {@see RefundResult} is returned (caller surfaces `->error`). On success the
+     * record's `refundedAmount`/`status` advance and {@see EVENT_PAYMENT_REFUNDED}
+     * fires. Commerce-mode refunds go through {@see RefundService} instead.
+     *
+     * @param int|null $amount Minor units; null = policy-allowed maximum.
+     * @throws RuntimeException on a guard violation. Its message is a translation
+     *                          key (e.g. `payment.refundExceedsPolicy`); the caller
+     *                          renders it with `Craft::t('booked', $e->getMessage())`.
+     */
+    public function refund(ReservationInterface $reservation, ?int $amount = null): RefundResult
+    {
+        /** @var PaymentRecord|null $record */
+        $record = PaymentRecord::find()
+            ->where(['reservationId' => $reservation->getId()])
+            ->orderBy(['dateCreated' => SORT_DESC])
+            ->one();
+
+        if (!$record || !in_array($record->status, [
+            PaymentRecord::STATUS_PAID,
+            PaymentRecord::STATUS_PARTIALLY_REFUNDED,
+        ], true)) {
+            throw new RuntimeException('payment.refundNoPayment');
+        }
+
+        $captured = (int) $record->amount;
+        $alreadyRefunded = (int) ($record->refundedAmount ?? 0);
+        $pct = Booked::getInstance()->getRefundPolicy()->calculateRefundPercentage($reservation);
+        $requested = self::resolveRefundAmount($captured, $alreadyRefunded, $pct, $amount);
+
+        $gateway = Booked::getInstance()->getPaymentGateways()->getGateway((string) $record->gateway);
+        if (!$gateway) {
+            throw new RuntimeException('payment.gatewayUnavailable');
+        }
+
+        $result = $gateway->refund($record, $requested);
+        if (!$result->success) {
+            return $result; // record untouched; caller surfaces $result->error
+        }
+
+        $totalRefunded = $alreadyRefunded + $result->refundedAmount;
+        $record->refundedAmount = $totalRefunded;
+        $record->status = $totalRefunded >= $captured
+            ? PaymentRecord::STATUS_REFUNDED
+            : PaymentRecord::STATUS_PARTIALLY_REFUNDED;
+        $record->save(false);
+
+        if ($this->hasEventHandlers(self::EVENT_PAYMENT_REFUNDED)) {
+            $event = new PaymentRefundedEvent();
+            $event->reservationId = (int) $record->reservationId;
+            $event->record = $record;
+            $event->amount = $result->refundedAmount;
+            $event->totalRefunded = $totalRefunded;
+            $this->trigger(self::EVENT_PAYMENT_REFUNDED, $event);
+        }
+
+        return $result;
     }
 
     /** Confirm a pending reservation (direct mode) and fire the usual notifications. */
@@ -176,6 +255,38 @@ class PaymentService extends Component
             return $commerceOrderPaid ? PaymentRecord::STATUS_PAID : PaymentRecord::STATUS_PENDING;
         }
         return self::STATUS_FREE; // mode 'none'
+    }
+
+    /**
+     * Pure refund-amount resolution (no I/O). Validates a requested refund against
+     * the refund-policy ceiling (a percentage of the captured amount, net of prior
+     * refunds) and the remaining refundable, returning the minor-unit amount to
+     * send to the gateway. `$requested` null = the policy-allowed maximum.
+     *
+     * Mirrors {@see resolveStatus} — the I/O-free core that {@see refund} wraps —
+     * so the money math is unit-testable without a DB or gateway.
+     *
+     * @throws RuntimeException with a translation-key message on any violation.
+     */
+    public static function resolveRefundAmount(int $captured, int $alreadyRefunded, int $policyPercent, ?int $requested): int
+    {
+        $remaining = $captured - $alreadyRefunded;
+        if ($remaining <= 0) {
+            throw new RuntimeException('payment.refundAlreadyFull');
+        }
+        $policyCeiling = max(0, (int) floor($captured * $policyPercent / 100) - $alreadyRefunded);
+
+        $amount = $requested ?? min($remaining, $policyCeiling);
+        if ($amount <= 0) {
+            throw new RuntimeException('payment.refundPolicyZero');
+        }
+        if ($amount > $remaining) {
+            throw new RuntimeException('payment.refundExceedsRemaining');
+        }
+        if ($amount > $policyCeiling) {
+            throw new RuntimeException('payment.refundExceedsPolicy');
+        }
+        return $amount;
     }
 
     /**

--- a/src/translations/en/booked.php
+++ b/src/translations/en/booked.php
@@ -1897,6 +1897,12 @@ return [
     'This feature requires Booked Pro.' => 'This feature requires Booked Pro.',
     'payment.gatewayUnavailable' => 'The payment gateway is not available.',
     'payment.createFailed' => 'The payment could not be started. Please try again.',
+    // Direct-payment refunds.
+    'payment.refundNoPayment' => 'This reservation has no refundable payment.',
+    'payment.refundAlreadyFull' => 'This payment has already been fully refunded.',
+    'payment.refundPolicyZero' => 'The refund policy allows no refund for this reservation.',
+    'payment.refundExceedsRemaining' => 'The refund exceeds the remaining refundable amount.',
+    'payment.refundExceedsPolicy' => 'The refund exceeds the amount allowed by the refund policy.',
     // Direct-payment wizard step (client-side status/errors).
     'payment.preparing' => 'Preparing secure payment…',
     'payment.processing' => 'Processing your payment…',

--- a/tests/Unit/PaymentServiceTest.php
+++ b/tests/Unit/PaymentServiceTest.php
@@ -6,6 +6,7 @@ use anvildev\booked\records\PaymentRecord;
 use anvildev\booked\services\PaymentService;
 use anvildev\booked\tests\Support\TestCase;
 use ReflectionMethod;
+use RuntimeException;
 
 class PaymentServiceTest extends TestCase
 {
@@ -129,5 +130,85 @@ class PaymentServiceTest extends TestCase
         $this->assertStringContainsString("\$action->id === 'webhook'", $src);
         $this->assertStringContainsString('$this->enableCsrfValidation = false', $src);
         $this->assertStringContainsString("'webhook'", $src);
+    }
+
+    // ---- resolveRefundAmount (pure refund math; #37) --------------------
+
+    public function testResolveRefundFullWithFullPolicy(): void
+    {
+        // 100% policy, nothing refunded yet, null → full captured amount.
+        $this->assertSame(4000, PaymentService::resolveRefundAmount(4000, 0, 100, null));
+    }
+
+    public function testResolveRefundNullCapsAtPolicyCeiling(): void
+    {
+        // 50% policy → null refunds half the captured amount, not the full remaining.
+        $this->assertSame(2000, PaymentService::resolveRefundAmount(4000, 0, 50, null));
+    }
+
+    public function testResolveRefundExplicitPartialWithinPolicy(): void
+    {
+        $this->assertSame(1500, PaymentService::resolveRefundAmount(4000, 0, 100, 1500));
+    }
+
+    public function testResolveRefundPolicyCeilingNetsPriorRefunds(): void
+    {
+        // 80% of 5000 = 4000 ceiling; 1000 already refunded → 3000 still allowed.
+        $this->assertSame(3000, PaymentService::resolveRefundAmount(5000, 1000, 80, null));
+        $this->assertSame(3000, PaymentService::resolveRefundAmount(5000, 1000, 80, 3000));
+    }
+
+    public function testResolveRefundZeroDecimalCurrencyAmounts(): void
+    {
+        // JPY captured 1000 (already minor units), 100% → 1000.
+        $this->assertSame(1000, PaymentService::resolveRefundAmount(1000, 0, 100, null));
+    }
+
+    public function testResolveRefundRejectsWhenAlreadyFullyRefunded(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('payment.refundAlreadyFull');
+        PaymentService::resolveRefundAmount(4000, 4000, 100, null);
+    }
+
+    public function testResolveRefundRejectsWhenPolicyAllowsNothing(): void
+    {
+        // 0% policy, null requested → nothing allowed.
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('payment.refundPolicyZero');
+        PaymentService::resolveRefundAmount(4000, 0, 0, null);
+    }
+
+    public function testResolveRefundRejectsAmountAbovePolicy(): void
+    {
+        // 50% policy = 2000 ceiling; asking 2500 is over policy though under remaining.
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('payment.refundExceedsPolicy');
+        PaymentService::resolveRefundAmount(4000, 0, 50, 2500);
+    }
+
+    public function testResolveRefundRejectsAmountAboveRemaining(): void
+    {
+        // 100% policy but 3500 already refunded → only 500 remains; asking 1000 fails.
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('payment.refundExceedsRemaining');
+        PaymentService::resolveRefundAmount(4000, 3500, 100, 1000);
+    }
+
+    public function testRefundMethodWiresPolicyGatewayAndEvent(): void
+    {
+        // The refund() orchestration is DB/gateway-bound; assert the wiring by
+        // source inspection (matches the source-scan style used above for the
+        // controller). The pure math it delegates to is covered by the cases above.
+        $src = self::methodSource('anvildev\booked\services\PaymentService', 'refund');
+        $this->assertStringContainsString('resolveRefundAmount(', $src);
+        $this->assertStringContainsString('calculateRefundPercentage(', $src);
+        $this->assertStringContainsString('$gateway->refund(', $src);
+        $this->assertStringContainsString('EVENT_PAYMENT_REFUNDED', $src);
+        // Status advances to fully- vs partially-refunded based on the running total.
+        $this->assertStringContainsString('STATUS_REFUNDED', $src);
+        $this->assertStringContainsString('STATUS_PARTIALLY_REFUNDED', $src);
+        // A failed gateway result must leave the record untouched.
+        $this->assertStringContainsString('if (!$result->success)', $src);
     }
 }


### PR DESCRIPTION
First slice of **M2** (epic #32). Adds direct (Commerce-free) refund execution to `PaymentService`, honoring `RefundPolicyService`.

## What
- **`PaymentService::refund(reservation, ?amount)`** — refunds a direct-mode `PaymentRecord` via `gateway->refund()`. `amount` is minor units; `null` = the policy-allowed maximum (capped at remaining refundable).
- **`PaymentService::resolveRefundAmount()`** — pure, I/O-free money math (mirrors the existing `resolveStatus()` pattern): the refund policy is a **hard ceiling** (a % of the captured amount, net of prior refunds); an explicit amount over the policy *or* over what's still refundable is rejected **before any gateway call**. Idempotent — a fully-refunded payment refuses further refunds; each call only ever adds up to the remaining.
- On success: `refundedAmount`/`status` advance (`refunded` vs `partiallyRefunded`) and **`EVENT_PAYMENT_REFUNDED`** (`PaymentRefundedEvent`) fires. On gateway failure the record is left untouched and the failed `RefundResult` is returned.
- Guard violations throw `RuntimeException` whose message is a **translation key** (rendered by the caller via `Craft::t`) — keeps the math unit-testable without a booted app.

## Decisions honored (§13)
- **No deposit math** — full-payment refunds only.
- Amounts stay **native minor units**; no cross-mode coercion.
- Commerce-mode refunds still go through the existing `RefundService` (untouched).

## No schema change
`booked_payments` already has `refundedAmount` + the `refunded`/`partiallyRefunded` statuses.

## Tests
10 new unit cases: full/partial/policy-capped/prior-refund-netting/zero-decimal amounts + every rejection path (already-full, policy-zero, over-policy, over-remaining), plus a wiring check on `refund()`. Full gate green (2710 tests; only the 2 pre-existing TZ soft-delete failures). ECS + PHPStan clean.

Follow-ups on this epic: #38 (CP payment panel), #39 (`booked:manageRefunds`), #40 (reports), #41 (CSV).

Closes #37