### PR TITLE
[M2] Revenue report reads captured amounts in direct mode (#40)

### DIFF
--- a/src/services/PaymentService.php
+++ b/src/services/PaymentService.php
@@ -196,6 +196,19 @@ class PaymentService extends Component
         return (int) round($amount * 100);
     }
 
+    /**
+     * Convert integer minor units back to a decimal major-unit amount for the
+     * currency — the inverse of {@see toMinorUnits}, used to render stored payment
+     * amounts (which are always minor units) in reports and exports.
+     */
+    public static function fromMinorUnits(int $minorUnits, string $currency): float
+    {
+        if (in_array(strtoupper($currency), self::ZERO_DECIMAL_CURRENCIES, true)) {
+            return (float) $minorUnits;
+        }
+        return $minorUnits / 100;
+    }
+
     private static function securityKey(): string
     {
         return (string) App::parseEnv(Craft::$app->getConfig()->getGeneral()->securityKey);

--- a/src/services/ReportsService.php
+++ b/src/services/ReportsService.php
@@ -9,6 +9,8 @@ use anvildev\booked\elements\Location;
 use anvildev\booked\elements\Service;
 use anvildev\booked\factories\ReservationFactory;
 use anvildev\booked\helpers\ElementQueryHelper;
+use anvildev\booked\models\Settings;
+use anvildev\booked\records\PaymentRecord;
 use Craft;
 use craft\base\Component;
 use yii\caching\TagDependency;
@@ -75,13 +77,18 @@ class ReportsService extends Component
     /**
      * Aggregate revenue for a date range.
      *
-     * Note: Revenue is calculated from catalog/service prices (service.price,
-     * eventDate.price, serviceExtra.price) multiplied by reservation quantities,
-     * NOT from actual payment amounts. If discounts, coupons, or partial payments
-     * are applied at checkout, those adjustments are not reflected here.
+     * In **direct** payment mode, revenue is the money actually captured
+     * (`amount − refundedAmount`) from the payments table — so refunds reduce the
+     * figure — per the §13 decision to reconcile minor units at the reports layer.
+     * In commerce/none mode it stays catalog-priced (service.price, eventDate.price,
+     * serviceExtra.price × quantity), which does not reflect discounts/coupons.
      */
     private function aggregateRevenueSum(string $startDate, string $endDate): float
     {
+        if (Booked::getInstance()->getSettings()->getPaymentMode() === Settings::PAYMENT_MODE_DIRECT) {
+            return $this->aggregateDirectPaymentsSum($startDate, $endDate);
+        }
+
         $query = (new Query())
             ->from('{{%booked_reservations}} r')
             ->leftJoin('{{%booked_services}} s', 'r.serviceId = s.id')
@@ -103,6 +110,35 @@ class ReportsService extends Component
         }
 
         return (float) $query->sum('COALESCE(s.price, 0) * r.quantity + COALESCE(ed.price, 0) * r.quantity + COALESCE(re_sum.extras_total, 0)');
+    }
+
+    /**
+     * Direct-mode revenue: net captured amount (`amount − refundedAmount`) across
+     * paid/refunded payment rows for confirmed reservations in the range, summed in
+     * minor units and converted once to the install-wide currency. Failed/pending
+     * rows are excluded (never captured). Honors the same staff scoping.
+     */
+    private function aggregateDirectPaymentsSum(string $startDate, string $endDate): float
+    {
+        $query = (new Query())
+            ->from('{{%booked_payments}} p')
+            ->innerJoin('{{%booked_reservations}} r', 'p.reservationId = r.id')
+            ->where(['r.status' => 'confirmed'])
+            ->andWhere(['between', 'r.bookingDate', $startDate, $endDate])
+            ->andWhere(['p.status' => [
+                PaymentRecord::STATUS_PAID,
+                PaymentRecord::STATUS_PARTIALLY_REFUNDED,
+                PaymentRecord::STATUS_REFUNDED,
+            ]]);
+
+        $staffIds = Booked::getInstance()->getPermission()->getStaffEmployeeIds();
+        if ($staffIds !== null) {
+            $query->andWhere(['r.employeeId' => $staffIds]);
+        }
+
+        $minorUnits = (int) $query->sum('p.amount - COALESCE(p.refundedAmount, 0)');
+
+        return PaymentService::fromMinorUnits($minorUnits, $this->getCurrency());
     }
 
     public function getByServiceData(?string $startDate = null, ?string $endDate = null): array

--- a/tests/Unit/PaymentServiceTest.php
+++ b/tests/Unit/PaymentServiceTest.php
@@ -25,6 +25,23 @@ class PaymentServiceTest extends TestCase
         $this->assertSame(1500, PaymentService::toMinorUnits(1500.0, 'VND'));
     }
 
+    public function testFromMinorUnitsRoundTripsToMinorUnits(): void
+    {
+        // Inverse of toMinorUnits — renders stored minor units back to major units.
+        $this->assertSame(40.0, PaymentService::fromMinorUnits(4000, 'USD'));
+        $this->assertSame(25.5, PaymentService::fromMinorUnits(2550, 'EUR'));
+        $this->assertSame(19.99, PaymentService::fromMinorUnits(1999, 'GBP'));
+        $this->assertSame(0.0, PaymentService::fromMinorUnits(0, 'USD'));
+    }
+
+    public function testFromMinorUnitsZeroDecimalCurrencyIsNotDivided(): void
+    {
+        // JPY/KRW/VND minor unit IS the major unit — no /100.
+        $this->assertSame(1000.0, PaymentService::fromMinorUnits(1000, 'JPY'));
+        $this->assertSame(5000.0, PaymentService::fromMinorUnits(5000, 'krw'));
+        $this->assertSame(1500.0, PaymentService::fromMinorUnits(1500, 'VND'));
+    }
+
     /**
      * @dataProvider finalizedProvider
      */

--- a/tests/Unit/ReportsServiceTest.php
+++ b/tests/Unit/ReportsServiceTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace anvildev\booked\tests\Unit;
+
+use anvildev\booked\tests\Support\TestCase;
+use ReflectionMethod;
+
+/**
+ * Reports revenue sourcing (#40).
+ *
+ * The aggregation SQL is DB-bound (skipped in the unit environment), so these
+ * assert the *wiring* by source inspection: in direct mode revenue comes from
+ * the payments table (net of refunds, in minor units → major), while
+ * commerce/none mode keeps the catalog-price path. The minor→major conversion
+ * itself is covered by {@see PaymentServiceTest}.
+ */
+class ReportsServiceTest extends TestCase
+{
+    private static function methodSource(string $method): string
+    {
+        $rm = new ReflectionMethod('anvildev\booked\services\ReportsService', $method);
+        $lines = file($rm->getFileName());
+        return implode('', array_slice($lines, $rm->getStartLine() - 1, $rm->getEndLine() - $rm->getStartLine() + 1));
+    }
+
+    public function testRevenueSumBranchesToPaymentsInDirectMode(): void
+    {
+        $src = self::methodSource('aggregateRevenueSum');
+        // Direct mode delegates to the payments-sourced aggregate...
+        $this->assertStringContainsString('PAYMENT_MODE_DIRECT', $src);
+        $this->assertStringContainsString('aggregateDirectPaymentsSum(', $src);
+        // ...and the catalog-price sum remains for the other modes.
+        $this->assertStringContainsString('s.price', $src);
+    }
+
+    public function testDirectPaymentsSumIsNetOfRefundsAndConverted(): void
+    {
+        $src = self::methodSource('aggregateDirectPaymentsSum');
+        // Net captured: amount minus refundedAmount.
+        $this->assertStringContainsString('p.amount - COALESCE(p.refundedAmount, 0)', $src);
+        // Only actually-captured rows count (not failed/pending).
+        $this->assertStringContainsString('STATUS_PAID', $src);
+        $this->assertStringContainsString('STATUS_PARTIALLY_REFUNDED', $src);
+        $this->assertStringContainsString('STATUS_REFUNDED', $src);
+        // Confirmed reservations only, and stored minor units → major currency once.
+        $this->assertStringContainsString("'r.status' => 'confirmed'", $src);
+        $this->assertStringContainsString('fromMinorUnits(', $src);
+        // Staff scoping preserved.
+        $this->assertStringContainsString('getStaffEmployeeIds()', $src);
+    }
+}


### PR DESCRIPTION
Part of **M2** (epic #32). Makes the revenue total reflect **actually captured** money in direct mode, per the §13 decision to reconcile minor units at the **reports layer** (not at storage).

## What
- `PaymentService::fromMinorUnits()` — the inverse of `toMinorUnits()` (zero-decimal-currency aware), for rendering stored minor-unit amounts.
- `ReportsService::aggregateRevenueSum()` now branches: in **direct** mode it delegates to a new `aggregateDirectPaymentsSum()` that sums `amount − refundedAmount` across paid/partially-refunded/refunded payment rows for confirmed reservations in the range, then converts minor→major once via the install-wide currency. **Refunds reduce revenue.**
- **Commerce/none mode unchanged** — still the catalog-price query. Storage stays native (no cross-mode coercion). Same staff-scoping + confirmed-only filters preserved.

## Scope note
This covers the headline revenue **total** (and previous-period comparison). The per-service/employee/location **breakdowns** still use catalog prices — they're attribution distributions; converting those to payment-sourced amounts is a separate follow-up if exact cross-breakdown reconciliation is wanted. Called out so it's a known boundary, not a silent gap.

## Tests
`fromMinorUnits` round-trip + zero-decimal cases (in `PaymentServiceTest`); `ReportsServiceTest` asserts the direct-mode branch, net-of-refunds SQL, captured-only status filter, and minor→major conversion. Full gate green (2704 tests; only the 2 pre-existing TZ failures). ECS + PHPStan clean.

Depended on by #41 (CSV columns).

Closes #40