### PR TITLE
[M2] Payment columns in bookings CSV export (#41)

### DIFF
--- a/src/controllers/cp/BookingsController.php
+++ b/src/controllers/cp/BookingsController.php
@@ -14,8 +14,10 @@ use anvildev\booked\elements\Service;
 use anvildev\booked\factories\ReservationFactory;
 use anvildev\booked\helpers\CsvHelper;
 use anvildev\booked\helpers\FormFieldHelper;
+use anvildev\booked\records\PaymentRecord;
 use anvildev\booked\records\ReservationRecord;
 use anvildev\booked\services\BookingService;
+use anvildev\booked\services\PaymentService;
 use Craft;
 use craft\web\Controller;
 use craft\web\Response;
@@ -559,9 +561,19 @@ class BookingsController extends Controller
 
         $query->orderBy(['bookingDate' => SORT_DESC, 'startTime' => SORT_DESC]);
 
+        // Direct-payment provenance columns are added only when the install is in
+        // direct mode; free/unpaid rows within it just leave those cells blank.
+        $directMode = Booked::getInstance()->getSettings()->isDirectPayment();
+        $currency = $directMode ? Booked::getInstance()->reports->getCurrency() : 'USD';
+
+        $header = ['ID', 'Name', 'Email', 'Phone', 'Service', 'Employee', 'Location', 'Event', 'Date', 'Start Time', 'End Time', 'Quantity', 'Status', 'Notes', 'Created'];
+        if ($directMode) {
+            array_push($header, 'Payment Status', 'Gateway', 'External ID', 'Refunded');
+        }
+
         $handle = fopen('php://temp', 'r+');
         fwrite($handle, "\xEF\xBB\xBF");
-        fputcsv($handle, ['ID', 'Name', 'Email', 'Phone', 'Service', 'Employee', 'Location', 'Event', 'Date', 'Start Time', 'End Time', 'Quantity', 'Status', 'Notes', 'Created']);
+        fputcsv($handle, $header);
 
         foreach ($query->each(100) as $r) {
             $service = $r->serviceId ? Service::find()->id($r->serviceId)->one() : null;
@@ -569,7 +581,7 @@ class BookingsController extends Controller
             $location = $r->locationId ? Location::find()->siteId('*')->id($r->locationId)->one() : null;
             $eventDate = $r->eventDateId ? EventDate::find()->id($r->eventDateId)->one() : null;
 
-            fputcsv($handle, [
+            $row = [
                 (string)$r->id,
                 CsvHelper::sanitizeValue($r->userName ?? ''),
                 CsvHelper::sanitizeValue($r->userEmail ?? ''),
@@ -585,7 +597,25 @@ class BookingsController extends Controller
                 (string)$r->getStatusLabel(),
                 CsvHelper::sanitizeValue($r->notes ?? ''),
                 $r->dateCreated ? $r->dateCreated->format('Y-m-d H:i:s') : '',
-            ]);
+            ];
+
+            if ($directMode) {
+                /** @var PaymentRecord|null $payment */
+                $payment = PaymentRecord::find()
+                    ->where(['reservationId' => $r->id])
+                    ->orderBy(['dateCreated' => SORT_DESC])
+                    ->one();
+                if ($payment) {
+                    $row[] = (string)$payment->status;
+                    $row[] = (string)$payment->gateway;
+                    $row[] = CsvHelper::sanitizeValue((string)$payment->externalId);
+                    $row[] = number_format(PaymentService::fromMinorUnits((int)($payment->refundedAmount ?? 0), $currency), 2, '.', '');
+                } else {
+                    array_push($row, '', '', '', '');
+                }
+            }
+
+            fputcsv($handle, $row);
         }
 
         rewind($handle);

--- a/tests/Unit/BookingsExportTest.php
+++ b/tests/Unit/BookingsExportTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace anvildev\booked\tests\Unit;
+
+use anvildev\booked\tests\Support\TestCase;
+use ReflectionMethod;
+
+/**
+ * Bookings CSV export payment columns (#41).
+ *
+ * The export streams from the DB (skipped in the unit environment), so this
+ * asserts by source inspection that the gateway/external-ID/status/refunded
+ * columns are added only in direct mode and sourced from the payment record.
+ */
+class BookingsExportTest extends TestCase
+{
+    private static function exportSource(): string
+    {
+        $rm = new ReflectionMethod('anvildev\booked\controllers\cp\BookingsController', 'actionExport');
+        $lines = file($rm->getFileName());
+        return implode('', array_slice($lines, $rm->getStartLine() - 1, $rm->getEndLine() - $rm->getStartLine() + 1));
+    }
+
+    public function testPaymentColumnsAreDirectModeOnly(): void
+    {
+        $src = self::exportSource();
+        $this->assertStringContainsString('isDirectPayment()', $src);
+        // Header additions guarded by the direct-mode flag.
+        $this->assertStringContainsString("'Payment Status', 'Gateway', 'External ID', 'Refunded'", $src);
+    }
+
+    public function testPaymentColumnsSourcedFromPaymentRecord(): void
+    {
+        $src = self::exportSource();
+        $this->assertStringContainsString('PaymentRecord::find()', $src);
+        $this->assertStringContainsString('$payment->status', $src);
+        $this->assertStringContainsString('$payment->gateway', $src);
+        $this->assertStringContainsString('$payment->externalId', $src);
+        // Refunded amount rendered from minor units.
+        $this->assertStringContainsString('fromMinorUnits(', $src);
+        // A reservation with no payment gets blank cells (not a missing column).
+        $this->assertStringContainsString("array_push(\$row, '', '', '', '')", $src);
+    }
+}


### PR DESCRIPTION
Final slice of **M2** (epic #32). Adds payment provenance to the bookings CSV export. Builds on the payments-sourced revenue work (#40).

## What
`BookingsController::actionExport()` — in **direct** mode the CSV gains four columns: **Payment Status, Gateway, External ID, Refunded** (the last rendered from minor units via `fromMinorUnits`). Free/unpaid rows within a direct-mode export leave the cells blank; commerce/none installs don't get the columns at all (no noise). External ID is sanitized plain text (the dashboard deep link stays a CP-only affordance, #38).

## Verified live (direct mode, dev)
Downloaded the export: header carries the 4 new columns; a row with a partially-refunded payment reads `partiallyRefunded, stripe, pi_test_…, 10.00` (1000 minor units → 10.00).

## Tests
`BookingsExportTest` (direct-mode-only columns, sourced from the payment record, blank cells when absent). Full gate green (2719 tests; only the 2 pre-existing TZ failures). ECS + PHPStan clean.

Closes #41