### PR TITLE
[M3] Webhook idempotency + refund sync + stricter payment rate-limiting (#47, #49)

### DIFF
--- a/src/controllers/PaymentController.php
+++ b/src/controllers/PaymentController.php
@@ -30,6 +30,9 @@ class PaymentController extends Controller
     use HandlesExceptionsTrait;
     use BookingHelpersTrait;
 
+    /** Per-reservation `create` attempts allowed per minute (IP-independent). */
+    private const PAYMENT_CREATE_PER_RESERVATION_LIMIT = 5;
+
     protected array|bool|int $allowAnonymous = ['create', 'confirm', 'webhook'];
 
     public $enableCsrfValidation = true;
@@ -64,13 +67,35 @@ class PaymentController extends Controller
             return $this->asJson(['received' => false])->setStatusCode(400);
         }
 
-        // Only payment-success events advance state; others are acked and ignored.
-        if ($event->status === PaymentRecord::STATUS_PAID && $event->externalId) {
+        // Idempotent delivery: gateways re-send events (retries, at-least-once).
+        // Drop a re-delivered event before touching any state. The TTL covers the
+        // gateway's retry window; the status/absolute-amount guards below are the
+        // durable backstop if the cache is evicted.
+        $cache = Craft::$app->getCache();
+        $dedupeKey = "booked:webhook:{$gateway}:{$event->eventId}";
+        if ($cache->exists($dedupeKey)) {
+            return $this->asJson(['received' => true, 'duplicate' => true]);
+        }
+
+        $payments = Booked::getInstance()->getPayments();
+        if ($event->externalId) {
             $record = PaymentRecord::findOne(['externalId' => $event->externalId, 'gateway' => $gateway]);
             if ($record) {
-                Booked::getInstance()->getPayments()->handleVerifiedPayment($record);
+                if ($event->status === PaymentRecord::STATUS_PAID) {
+                    $payments->handleVerifiedPayment($record);
+                } elseif (
+                    in_array($event->status, [PaymentRecord::STATUS_REFUNDED, PaymentRecord::STATUS_PARTIALLY_REFUNDED], true)
+                    && $event->refundedAmount !== null
+                ) {
+                    // A refund issued outside Booked (e.g. the Stripe dashboard).
+                    $payments->applyRefundSync($record, $event->refundedAmount);
+                }
             }
         }
+
+        // Mark processed only after handling succeeded — a thrown handler leaves
+        // the key unset so the gateway's retry can reprocess.
+        $cache->set($dedupeKey, true, 60 * 60 * 72);
 
         // Always 200 a verified event so the gateway stops retrying.
         return $this->asJson(['received' => true]);
@@ -81,7 +106,7 @@ class PaymentController extends Controller
         $this->requirePostRequest();
         $this->requireAcceptsJson();
 
-        // Stricter, separate bucket from booking submission.
+        // Stricter, separate bucket from booking submission (per-IP).
         if (!$this->checkRateLimit('booked_payment_throttle', 20)) {
             return $this->jsonError(Craft::t('booked', 'booking.rateLimitIP'), statusCode: 429);
         }
@@ -89,6 +114,16 @@ class PaymentController extends Controller
         $request = Craft::$app->request;
         $reservationId = (int) $request->getRequiredBodyParam('reservationId');
         $token = (string) $request->getRequiredBodyParam('token');
+
+        // Second, tighter bucket keyed by the reservation itself (IP-independent):
+        // blunts token-guessing that rotates IPs to hammer a single reservation.
+        // `checkRateLimit` folds the IP into its key, so count directly here.
+        $resThrottleKey = "booked_payment_create_res_{$reservationId}";
+        $resAttempts = (int) (Craft::$app->getCache()->get($resThrottleKey) ?: 0);
+        if ($resAttempts >= self::PAYMENT_CREATE_PER_RESERVATION_LIMIT) {
+            return $this->jsonError(Craft::t('booked', 'booking.rateLimitIP'), statusCode: 429);
+        }
+        Craft::$app->getCache()->set($resThrottleKey, $resAttempts + 1, 60);
 
         $reservation = ReservationFactory::findById($reservationId);
         if (!$reservation || !hash_equals($reservation->getConfirmationToken(), $token)) {

--- a/src/gateways/StripeGateway.php
+++ b/src/gateways/StripeGateway.php
@@ -124,6 +124,28 @@ class StripeGateway implements PaymentGatewayInterface
 
         $object = $event->data->object ?? null;
 
+        // Refund events (e.g. a refund issued in the Stripe dashboard): normalize
+        // to the parent PaymentIntent + the absolute refunded total so the caller
+        // can reconcile it against the local record. The charge object carries the
+        // intent id and the running `amount_refunded`.
+        if ($event->type === 'charge.refunded' && is_object($object)) {
+            $intentId = $object->payment_intent ?? null;
+            $refunded = isset($object->amount_refunded) ? (int) $object->amount_refunded : 0;
+            $captured = isset($object->amount) ? (int) $object->amount : null;
+            $status = ($captured !== null && $refunded >= $captured)
+                ? PaymentRecord::STATUS_REFUNDED
+                : PaymentRecord::STATUS_PARTIALLY_REFUNDED;
+
+            return new WebhookEvent(
+                $event->type,
+                $event->id,
+                is_string($intentId) ? $intentId : null,
+                $status,
+                $event->toArray(),
+                $refunded,
+            );
+        }
+
         return new WebhookEvent(
             $event->type,
             $event->id,

--- a/src/payments/WebhookEvent.php
+++ b/src/payments/WebhookEvent.php
@@ -15,6 +15,9 @@ final class WebhookEvent
      * @param string|null $externalId Related payment id, when applicable.
      * @param string|null $status Resolved payment status, when applicable.
      * @param array<string, mixed> $raw Raw verified event payload.
+     * @param int|null $refundedAmount Absolute refunded total (minor units) for
+     *                                 refund events, else null. Used to reconcile
+     *                                 refunds issued outside Booked.
      */
     public function __construct(
         public readonly string $type,
@@ -22,6 +25,7 @@ final class WebhookEvent
         public readonly ?string $externalId = null,
         public readonly ?string $status = null,
         public readonly array $raw = [],
+        public readonly ?int $refundedAmount = null,
     ) {
     }
 }

--- a/src/services/PaymentService.php
+++ b/src/services/PaymentService.php
@@ -177,6 +177,43 @@ class PaymentService extends Component
         return $result;
     }
 
+    /**
+     * Reconcile a refund observed via webhook — e.g. one issued directly in the
+     * gateway dashboard, which never went through {@see refund()}. Sets the
+     * record's *absolute* refunded total + status. Idempotent: re-delivering the
+     * same webhook writes the same value, so it never compounds.
+     */
+    public function applyRefundSync(PaymentRecord $record, int $refundedAmount): void
+    {
+        $captured = (int) $record->amount;
+        $refundedAmount = max(0, min($refundedAmount, $captured));
+        if ($refundedAmount === 0) {
+            return;
+        }
+
+        $status = $refundedAmount >= $captured
+            ? PaymentRecord::STATUS_REFUNDED
+            : PaymentRecord::STATUS_PARTIALLY_REFUNDED;
+
+        // Nothing changed (already reconciled to this total) — stay a no-op.
+        if ((int) ($record->refundedAmount ?? 0) === $refundedAmount && $record->status === $status) {
+            return;
+        }
+
+        $record->refundedAmount = $refundedAmount;
+        $record->status = $status;
+        $record->save(false);
+
+        if ($this->hasEventHandlers(self::EVENT_PAYMENT_REFUNDED)) {
+            $event = new PaymentRefundedEvent();
+            $event->reservationId = (int) $record->reservationId;
+            $event->record = $record;
+            $event->amount = $refundedAmount;
+            $event->totalRefunded = $refundedAmount;
+            $this->trigger(self::EVENT_PAYMENT_REFUNDED, $event);
+        }
+    }
+
     /** Confirm a pending reservation (direct mode) and fire the usual notifications. */
     private function confirmReservation(int $reservationId): void
     {

--- a/tests/Unit/PaymentServiceTest.php
+++ b/tests/Unit/PaymentServiceTest.php
@@ -149,6 +149,64 @@ class PaymentServiceTest extends TestCase
         $this->assertStringContainsString("'webhook'", $src);
     }
 
+    // ---- Webhook hardening + rate-limit (#47/#49) -----------------------
+
+    public function testWebhookEventCarriesRefundedAmount(): void
+    {
+        $e = new \anvildev\booked\payments\WebhookEvent(
+            'charge.refunded',
+            'evt_1',
+            'pi_1',
+            PaymentRecord::STATUS_PARTIALLY_REFUNDED,
+            [],
+            1000,
+        );
+        $this->assertSame(1000, $e->refundedAmount);
+        $this->assertSame('pi_1', $e->externalId);
+        $this->assertSame(PaymentRecord::STATUS_PARTIALLY_REFUNDED, $e->status);
+    }
+
+    public function testWebhookDedupesByEventIdAndRoutesRefunds(): void
+    {
+        $src = self::methodSource('anvildev\booked\controllers\PaymentController', 'actionWebhook');
+        // Event-ID dedup before any state change.
+        $this->assertStringContainsString('booked:webhook:', $src);
+        $this->assertStringContainsString('->exists($dedupeKey)', $src);
+        // Paid still confirms; refunds route to the idempotent sync.
+        $this->assertStringContainsString('handleVerifiedPayment(', $src);
+        $this->assertStringContainsString('applyRefundSync(', $src);
+        // Processed marker set only after handling.
+        $this->assertStringContainsString('->set($dedupeKey', $src);
+    }
+
+    public function testApplyRefundSyncIsAbsoluteAndIdempotent(): void
+    {
+        $src = self::methodSource('anvildev\booked\services\PaymentService', 'applyRefundSync');
+        // Absolute set (clamped to captured), not an increment.
+        $this->assertStringContainsString('min($refundedAmount, $captured)', $src);
+        $this->assertStringContainsString('$record->refundedAmount = $refundedAmount', $src);
+        // No-op when already reconciled to this total.
+        $this->assertStringContainsString('return;', $src);
+        $this->assertStringContainsString('EVENT_PAYMENT_REFUNDED', $src);
+    }
+
+    public function testStripeNormalizesRefundEventToIntent(): void
+    {
+        $src = self::methodSource('anvildev\booked\gateways\StripeGateway', 'verifyWebhook');
+        $this->assertStringContainsString("'charge.refunded'", $src);
+        $this->assertStringContainsString('payment_intent', $src);
+        $this->assertStringContainsString('amount_refunded', $src);
+    }
+
+    public function testPaymentCreateHasPerReservationBucket(): void
+    {
+        $src = self::methodSource('anvildev\booked\controllers\PaymentController', 'actionCreate');
+        $this->assertStringContainsString('PAYMENT_CREATE_PER_RESERVATION_LIMIT', $src);
+        $this->assertStringContainsString('booked_payment_create_res_', $src);
+        // The per-IP bucket is still enforced too.
+        $this->assertStringContainsString("checkRateLimit('booked_payment_throttle'", $src);
+    }
+
     // ---- resolveRefundAmount (pure refund math; #37) --------------------
 
     public function testResolveRefundFullWithFullPolicy(): void


### PR DESCRIPTION
First slice of **M3 hardening** (epic #33). Two `PaymentController` concerns grouped in one PR (same file).

## #47 — Webhook idempotency + gateway refund sync
- **Event-ID dedup:** `actionWebhook` records processed gateway event IDs (cache, 72h TTL covering the retry window) and drops a re-delivered event before touching state — cheap explicit dedup on top of the durable status/absolute-amount guards.
- **Refund sync:** `StripeGateway::verifyWebhook` now normalizes `charge.refunded` to the parent PaymentIntent + absolute refunded total; `PaymentService::applyRefundSync()` reconciles the record's `refundedAmount`/status. This makes **refunds issued in the Stripe dashboard** reflect in Booked. Idempotent by absolute-set (not increment). `WebhookEvent` gained a `refundedAmount` field.

## #49 — Stricter payment/create rate-limiting
- Added a **per-reservation** bucket (IP-independent, 5/min) on top of the existing per-IP bucket, to blunt token-guessing that rotates IPs against one reservation.

## Verified live (Stripe test mode)
Real PaymentIntent captured → partial refund via the Stripe API → forwarded `charge.refunded` webhook → record synced to `partiallyRefunded / 3500` (from `9000` captured). Unsigned webhook → 400; other refund event types correctly ignored. (Also fixed an unrelated broken **site autoloader** — a stale phpunit reference was fatal-erroring every request in the dev env — via `composer dump-autoload`.)

## Tests
`PaymentServiceTest`: `WebhookEvent.refundedAmount` value, event-ID dedup + refund routing, `applyRefundSync` absolute/idempotent, Stripe refund normalization, per-reservation bucket. Full gate green (2728 tests; only the 2 pre-existing TZ failures). ECS + PHPStan clean.

Closes #47
Closes #49