### PR TITLE
[M3] Pending-payment garbage collection (#48)

### DIFF
--- a/src/Booked.php
+++ b/src/Booked.php
@@ -102,7 +102,7 @@ class Booked extends Plugin
     public const EDITION_LITE = Editions::LITE;
     public const EDITION_PRO = Editions::PRO;
 
-    public string $schemaVersion = '1.4.0';
+    public string $schemaVersion = '1.4.1';
     public bool $hasCpSection = true;
     public bool $hasCpSettings = true;
 

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -84,6 +84,7 @@ class Install extends Migration
                 'stripePublishableKey' => $this->text()->null(),
                 'stripeSecretKey' => $this->text()->null(),
                 'stripeWebhookSecret' => $this->text()->null(),
+                'pendingPaymentTtlMinutes' => $this->integer()->notNull()->defaultValue(30),
                 'commerceEnabled' => $this->boolean()->notNull()->defaultValue(false),
                 'commerceTaxCategoryId' => $this->integer()->null(),
                 'pendingCartExpirationHours' => $this->integer()->notNull()->defaultValue(48),

--- a/src/migrations/m260727_000000_add_pending_payment_ttl.php
+++ b/src/migrations/m260727_000000_add_pending_payment_ttl.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace anvildev\booked\migrations;
+
+use craft\db\Migration;
+
+/**
+ * Add the `pendingPaymentTtlMinutes` setting column to booked_settings — how long
+ * a direct-payment booking may stay pending before it's garbage-collected. Booked
+ * persists settings column-per-attribute, so the column must exist to save/load.
+ */
+class m260727_000000_add_pending_payment_ttl extends Migration
+{
+    public function safeUp(): bool
+    {
+        $table = '{{%booked_settings}}';
+        if (!$this->db->columnExists($table, 'pendingPaymentTtlMinutes')) {
+            $this->addColumn(
+                $table,
+                'pendingPaymentTtlMinutes',
+                $this->integer()->notNull()->defaultValue(30)->after('stripeWebhookSecret'),
+            );
+        }
+        return true;
+    }
+
+    public function safeDown(): bool
+    {
+        $table = '{{%booked_settings}}';
+        if ($this->db->columnExists($table, 'pendingPaymentTtlMinutes')) {
+            $this->dropColumn($table, 'pendingPaymentTtlMinutes');
+        }
+        return true;
+    }
+}

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -131,6 +131,11 @@ class Settings extends Model
     public ?string $stripeSecretKey = null;
     public ?string $stripeWebhookSecret = null;
 
+    // Minutes a direct-payment booking may stay `pending` before it's garbage-
+    // collected (its reservation cancelled, releasing capacity). Abandoned Stripe
+    // Elements checkouts are freed on this cadence. See MaintenanceService.
+    public int $pendingPaymentTtlMinutes = 30;
+
     // Commerce
     public bool $commerceEnabled = false;
     public ?int $commerceTaxCategoryId = null;
@@ -282,6 +287,7 @@ class Settings extends Model
             [['stripePublishableKey', 'stripeSecretKey', 'stripeWebhookSecret'], 'string'],
             [['commerceTaxCategoryId'], 'integer', 'skipOnEmpty' => true],
             [['pendingCartExpirationHours'], 'integer', 'min' => 1, 'max' => 168],
+            [['pendingPaymentTtlMinutes'], 'integer', 'min' => 5, 'max' => 1440],
             [['commerceCartUrl', 'commerceCheckoutUrl'], 'string', 'max' => 255],
             [['enableAutoRefund'], 'boolean'],
             [['defaultRefundTiers'], 'safe'],
@@ -416,6 +422,7 @@ class Settings extends Model
             ],
             'payments' => [
                 'paymentMode', 'stripePublishableKey', 'stripeSecretKey', 'stripeWebhookSecret',
+                'pendingPaymentTtlMinutes',
             ],
             'commerce' => [
                 'defaultCurrency', 'commerceEnabled', 'commerceTaxCategoryId', 'pendingCartExpirationHours',

--- a/src/services/MaintenanceService.php
+++ b/src/services/MaintenanceService.php
@@ -5,6 +5,7 @@ namespace anvildev\booked\services;
 use anvildev\booked\Booked;
 use anvildev\booked\records\CalendarInviteRecord;
 use anvildev\booked\records\OAuthStateTokenRecord;
+use anvildev\booked\records\PaymentRecord;
 use anvildev\booked\records\ReservationRecord;
 use Craft;
 use craft\base\Component;
@@ -27,6 +28,7 @@ class MaintenanceService extends Component
             'expiredWaitlist' => $this->cleanupExpiredWaitlist(),
             'webhookLogs' => $this->cleanupOldWebhookLogs(),
             'stalePendingReservations' => $this->cleanupStalePendingReservations(),
+            'stalePendingPayments' => $this->cleanupStalePendingPayments(),
             'expiredOAuthTokens' => $this->cleanupExpiredOAuthTokens(),
             'expiredCalendarInvites' => $this->cleanupExpiredCalendarInvites(),
         ];
@@ -117,6 +119,63 @@ class MaintenanceService extends Component
             return $cancelled;
         } catch (\Throwable $e) {
             Craft::error("Failed to cleanup stale pending reservations: {$e->getMessage()}", __METHOD__);
+            return 0;
+        }
+    }
+
+    /**
+     * Garbage-collect abandoned **direct-payment** bookings: reservations left
+     * `pending` past the configured TTL whose Stripe checkout was never completed.
+     * Cancelling them releases the held capacity. Complements
+     * {@see cleanupStalePendingReservations} (which is Commerce-only) — this covers
+     * the direct-mode path, where there is no Commerce order to key off.
+     *
+     * A reservation with a paid/refunded payment record is *never* cancelled, so a
+     * webhook that lands right at the TTL boundary can't lose a booking the
+     * customer actually paid for. No-op outside direct mode.
+     */
+    public function cleanupStalePendingPayments(?int $minutes = null): int
+    {
+        $settings = Booked::getInstance()->getSettings();
+        if (!$settings->isDirectPayment()) {
+            return 0;
+        }
+
+        $minutes = max(1, (int) ($minutes ?? $settings->pendingPaymentTtlMinutes));
+
+        try {
+            $cutoff = (new \DateTime("-{$minutes} minutes"))->format('Y-m-d H:i:s');
+
+            // Reservations that HAVE been paid must be excluded even if their
+            // confirm lost a race — never cancel a paid booking.
+            $paidReservationIds = (new Query())
+                ->select('reservationId')
+                ->from('{{%booked_payments}}')
+                ->where(['status' => [
+                    PaymentRecord::STATUS_PAID,
+                    PaymentRecord::STATUS_PARTIALLY_REFUNDED,
+                    PaymentRecord::STATUS_REFUNDED,
+                ]])
+                ->column();
+
+            $query = (new Query())
+                ->select('id')
+                ->from('{{%booked_reservations}}')
+                ->where(['status' => ReservationRecord::STATUS_PENDING])
+                ->andWhere(['<=', 'dateCreated', $cutoff]);
+            if ($paidReservationIds) {
+                $query->andWhere(['not in', 'id', $paidReservationIds]);
+            }
+
+            $cancelled = 0;
+            foreach ($query->column() as $id) {
+                $this->cancelStaleReservation((int) $id, "Direct payment not completed within {$minutes} minutes");
+                $cancelled++;
+            }
+
+            return $cancelled;
+        } catch (\Throwable $e) {
+            Craft::error("Failed to cleanup stale pending payments: {$e->getMessage()}", __METHOD__);
             return 0;
         }
     }

--- a/tests/Unit/MaintenancePendingPaymentsTest.php
+++ b/tests/Unit/MaintenancePendingPaymentsTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace anvildev\booked\tests\Unit;
+
+use anvildev\booked\models\Settings;
+use anvildev\booked\services\MaintenanceService;
+use anvildev\booked\tests\Support\TestCase;
+use ReflectionMethod;
+use ReflectionProperty;
+
+/**
+ * Pending-payment garbage collection (#48).
+ *
+ * The GC query is DB-bound (skipped in the unit environment), so the sweep logic
+ * is asserted by source inspection: direct-mode-only, TTL-cutoff, and paid
+ * bookings excluded. The setting default is read via reflection (no Craft app).
+ */
+class MaintenancePendingPaymentsTest extends TestCase
+{
+    private static function methodSource(string $method): string
+    {
+        $rm = new ReflectionMethod(MaintenanceService::class, $method);
+        $lines = file($rm->getFileName());
+        return implode('', array_slice($lines, $rm->getStartLine() - 1, $rm->getEndLine() - $rm->getStartLine() + 1));
+    }
+
+    public function testTtlSettingDefaultsToThirtyMinutes(): void
+    {
+        $default = (new ReflectionProperty(Settings::class, 'pendingPaymentTtlMinutes'))->getDefaultValue();
+        $this->assertSame(30, $default);
+    }
+
+    public function testGcIsDirectModeOnly(): void
+    {
+        $src = self::methodSource('cleanupStalePendingPayments');
+        $this->assertStringContainsString('isDirectPayment()', $src);
+        $this->assertStringContainsString('pendingPaymentTtlMinutes', $src);
+    }
+
+    public function testGcTargetsStalePendingAndExcludesPaid(): void
+    {
+        $src = self::methodSource('cleanupStalePendingPayments');
+        // Only pending reservations older than the cutoff.
+        $this->assertStringContainsString('STATUS_PENDING', $src);
+        $this->assertStringContainsString("['<=', 'dateCreated', \$cutoff]", $src);
+        // Paid/refunded bookings are excluded — never cancel a paid booking.
+        $this->assertStringContainsString('STATUS_PAID', $src);
+        $this->assertStringContainsString("['not in', 'id', \$paidReservationIds]", $src);
+        $this->assertStringContainsString('cancelStaleReservation(', $src);
+    }
+
+    public function testGcRegisteredInRunAll(): void
+    {
+        $src = self::methodSource('runAll');
+        $this->assertStringContainsString('cleanupStalePendingPayments()', $src);
+    }
+}


### PR DESCRIPTION
Part of **M3 hardening** (epic #33). Garbage-collects abandoned direct-payment bookings.

## Gap
`MaintenanceService::cleanupStalePendingReservations()` is Commerce-only (guards on `canUseCommerce()`, joins the order-reservation link). A **direct-pay** booking left `pending` — customer abandons the Stripe Elements step — was never GC'd and held capacity indefinitely.

## What
- **`MaintenanceService::cleanupStalePendingPayments()`** — cancels reservations still `pending` past a configurable TTL, releasing capacity. Registered in `runAll()` (Craft `Gc::EVENT_RUN`). Direct-mode only (no-op otherwise). **A paid/refunded booking is never cancelled** (excluded via a payments subquery), so a webhook landing at the TTL boundary can't lose a paid booking.
- **`pendingPaymentTtlMinutes` setting** (default 30, 5–1440) + `booked_settings` column + Install.php + migration `m260727_000000` + schemaVersion `1.4.0` → `1.4.1`.

## Verified live (dev, direct mode)
Ran the migration; inserted a stale (hours-old) pending reservation + a fresh one → `php craft gc` → stale one `cancelled` ("Direct payment not completed within 30 minutes"), fresh one untouched.

## Tests
`MaintenancePendingPaymentsTest` — TTL default, direct-mode guard, stale-pending targeting, paid-exclusion, `runAll` registration. Full gate green (2732 tests; only the 2 pre-existing TZ failures). ECS + PHPStan clean.

Closes #48