### PR TITLE
[M3] Doctor payment checks + payments/reconcile console command (#50, #51)

### DIFF
--- a/src/console/controllers/DoctorController.php
+++ b/src/console/controllers/DoctorController.php
@@ -7,6 +7,7 @@ use anvildev\booked\models\Settings;
 use anvildev\booked\records\WebhookLogRecord;
 use Craft;
 use craft\console\Controller;
+use craft\helpers\App;
 use yii\console\ExitCode;
 use yii\helpers\Console;
 
@@ -44,6 +45,7 @@ class DoctorController extends Controller
         $this->checkTwilioSms($settings);
         $this->checkCaptcha($settings);
         $this->checkWebhooks($settings);
+        $this->checkPayments($settings);
         $this->checkQueue();
 
         $this->stdout("═══════════════════════════════════\n");
@@ -339,6 +341,73 @@ class DoctorController extends Controller
                 ? $this->warn("Recent deliveries: {$failures}/{$logCount} failed (" . round(($failures / $logCount) * 100) . "%) in last 7 days")
                 : $this->pass("Recent deliveries: {$logCount} successful in last 7 days");
         }
+    }
+
+    /**
+     * Direct-payment configuration checks: Stripe keys present + well-formed, the
+     * webhook secret set (else payments never confirm), the gateway registered,
+     * the currency resolvable, and test/live keys matched to the environment.
+     * No-op unless payment mode is `direct`.
+     */
+    private function checkPayments(Settings $settings): void
+    {
+        if ($settings->getPaymentMode() !== Settings::PAYMENT_MODE_DIRECT) {
+            return;
+        }
+
+        $this->heading('Direct Payments', true);
+
+        $secret = (string) App::parseEnv($settings->stripeSecretKey);
+        $publishable = (string) App::parseEnv($settings->stripePublishableKey);
+        $webhookSecret = (string) App::parseEnv($settings->stripeWebhookSecret);
+
+        // Secret key
+        if ($secret === '') {
+            $this->fail('Stripe secret key is not set');
+        } elseif (!str_starts_with($secret, 'sk_')) {
+            $this->fail('Stripe secret key is malformed (expected sk_…)');
+        } else {
+            $this->pass('Stripe secret key is set');
+        }
+
+        // Publishable key — guard against a secret key pasted into the public field.
+        if ($publishable === '') {
+            $this->fail('Stripe publishable key is not set');
+        } elseif (str_starts_with($publishable, 'sk_')) {
+            $this->fail('A SECRET key is configured as the publishable key — replace it with pk_…');
+        } elseif (!str_starts_with($publishable, 'pk_')) {
+            $this->warn('Stripe publishable key is malformed (expected pk_…)');
+        } else {
+            $this->pass('Stripe publishable key is set');
+        }
+
+        // Webhook secret — without it verifyWebhook() drops everything and payments never confirm.
+        if ($webhookSecret === '') {
+            $this->fail('Stripe webhook secret is not set — webhooks cannot be verified, so payments will never confirm');
+        } elseif (!str_starts_with($webhookSecret, 'whsec_')) {
+            $this->warn('Stripe webhook secret is malformed (expected whsec_…)');
+        } else {
+            $this->pass('Stripe webhook secret is set');
+        }
+
+        // Test/live keys vs environment.
+        $devMode = Craft::$app->getConfig()->getGeneral()->devMode;
+        if (str_starts_with($secret, 'sk_live_') && $devMode) {
+            $this->warn('LIVE Stripe keys with devMode ON — real charges from a dev environment');
+        }
+        if (str_starts_with($secret, 'sk_test_') && !$devMode) {
+            $this->warn('TEST Stripe keys with devMode OFF — a production site would take no real payments');
+        }
+
+        // Gateway registered + currency resolvable.
+        Booked::getInstance()->getPaymentGateways()->getGateway('stripe')
+            ? $this->pass('Stripe gateway is registered')
+            : $this->fail('Stripe gateway is not registered');
+
+        $currency = Booked::getInstance()->reports->getCurrency();
+        $currency !== ''
+            ? $this->pass("Payment currency resolves to {$currency}")
+            : $this->warn('Payment currency could not be resolved');
     }
 
     private function checkQueue(): void

--- a/src/console/controllers/PaymentsController.php
+++ b/src/console/controllers/PaymentsController.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace anvildev\booked\console\controllers;
+
+use anvildev\booked\Booked;
+use anvildev\booked\models\Settings;
+use anvildev\booked\records\PaymentRecord;
+use craft\console\Controller;
+use yii\console\ExitCode;
+use yii\helpers\Console;
+
+/**
+ * Direct-payment maintenance commands.
+ */
+class PaymentsController extends Controller
+{
+    /** Report what would change without writing anything. */
+    public bool $dryRun = false;
+
+    /** Only reconcile payments created within the last N days (0 = all non-finalized). */
+    public int $since = 7;
+
+    public function options($actionID): array
+    {
+        return array_merge(parent::options($actionID), ['dryRun', 'since']);
+    }
+
+    public function optionAliases(): array
+    {
+        return array_merge(parent::optionAliases(), ['d' => 'dryRun']);
+    }
+
+    /**
+     * Reconcile local payment records against the gateway — a safety net for
+     * missed/dropped webhooks. Re-queries each non-finalized record; a payment the
+     * gateway reports as paid is finalized through the SAME idempotent path as the
+     * webhook (`handleVerifiedPayment`), so it never double-confirms. Safe to
+     * re-run. Direct mode only.
+     */
+    public function actionReconcile(): int
+    {
+        $settings = Booked::getInstance()->getSettings();
+        if ($settings->getPaymentMode() !== Settings::PAYMENT_MODE_DIRECT) {
+            $this->stdout("Payment mode is not 'direct' — nothing to reconcile.\n", Console::FG_YELLOW);
+            return ExitCode::OK;
+        }
+
+        $query = PaymentRecord::find()->where(['not in', 'status', [
+            PaymentRecord::STATUS_PAID,
+            PaymentRecord::STATUS_REFUNDED,
+            PaymentRecord::STATUS_PARTIALLY_REFUNDED,
+            PaymentRecord::STATUS_FAILED,
+        ]]);
+        if ($this->since > 0) {
+            $cutoff = (new \DateTime("-{$this->since} days"))->format('Y-m-d H:i:s');
+            $query->andWhere(['>=', 'dateCreated', $cutoff]);
+        }
+
+        /** @var PaymentRecord[] $records */
+        $records = $query->all();
+        if (!$records) {
+            $this->stdout("No non-finalized payments to reconcile.\n", Console::FG_GREEN);
+            return ExitCode::OK;
+        }
+
+        $gateways = Booked::getInstance()->getPaymentGateways();
+        $payments = Booked::getInstance()->getPayments();
+        $reconciled = 0;
+        $failed = 0;
+
+        foreach ($records as $record) {
+            $gateway = $gateways->getGateway((string) $record->gateway);
+            if (!$gateway) {
+                $this->stdout("  ? payment #{$record->id}: gateway '{$record->gateway}' unavailable — skipped\n", Console::FG_YELLOW);
+                continue;
+            }
+
+            try {
+                $result = $gateway->confirmPayment((string) $record->externalId);
+            } catch (\Throwable $e) {
+                $failed++;
+                $this->stdout("  ✗ payment #{$record->id}: {$e->getMessage()}\n", Console::FG_RED);
+                continue;
+            }
+
+            if ($result->paid) {
+                if ($this->dryRun) {
+                    $this->stdout("  ~ payment #{$record->id}: WOULD confirm (gateway reports paid)\n", Console::FG_CYAN);
+                } else {
+                    $payments->handleVerifiedPayment($record);
+                    $this->stdout("  ✓ payment #{$record->id}: confirmed from gateway\n", Console::FG_GREEN);
+                }
+                $reconciled++;
+            } else {
+                $this->stdout("  · payment #{$record->id}: gateway status '{$result->status}' — no change\n");
+            }
+        }
+
+        $verb = $this->dryRun ? 'would be reconciled' : 'reconciled';
+        $this->stdout("\n{$reconciled} {$verb}, {$failed} failed, " . count($records) . " checked.\n", Console::FG_GREEN);
+
+        return $failed > 0 ? ExitCode::UNSPECIFIED_ERROR : ExitCode::OK;
+    }
+}

--- a/tests/Unit/PaymentOpsTest.php
+++ b/tests/Unit/PaymentOpsTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace anvildev\booked\tests\Unit;
+
+use anvildev\booked\tests\Support\TestCase;
+use ReflectionMethod;
+
+/**
+ * Payment ops: Doctor config checks (#50) + reconcile console command (#51).
+ *
+ * Both are console/DB-bound (skipped in the unit environment), so the logic is
+ * asserted by source inspection: the Doctor validates key shapes + the webhook
+ * secret and matches test/live keys to the environment; the reconcile command
+ * re-queries non-finalized records and finalizes via the idempotent path.
+ */
+class PaymentOpsTest extends TestCase
+{
+    private static function methodSource(string $class, string $method): string
+    {
+        $rm = new ReflectionMethod($class, $method);
+        $lines = file($rm->getFileName());
+        return implode('', array_slice($lines, $rm->getStartLine() - 1, $rm->getEndLine() - $rm->getStartLine() + 1));
+    }
+
+    public function testDoctorPaymentChecksAreDirectModeOnly(): void
+    {
+        $src = self::methodSource('anvildev\booked\console\controllers\DoctorController', 'checkPayments');
+        $this->assertStringContainsString('PAYMENT_MODE_DIRECT', $src);
+    }
+
+    public function testDoctorValidatesKeyShapesAndWebhookSecret(): void
+    {
+        $src = self::methodSource('anvildev\booked\console\controllers\DoctorController', 'checkPayments');
+        // Key-prefix validation, incl. the secret-as-publishable footgun.
+        $this->assertStringContainsString("str_starts_with(\$secret, 'sk_')", $src);
+        $this->assertStringContainsString("str_starts_with(\$publishable, 'sk_')", $src);
+        $this->assertStringContainsString("str_starts_with(\$publishable, 'pk_')", $src);
+        $this->assertStringContainsString("str_starts_with(\$webhookSecret, 'whsec_')", $src);
+        // Test/live keys matched to devMode.
+        $this->assertStringContainsString("str_starts_with(\$secret, 'sk_live_')", $src);
+        $this->assertStringContainsString("str_starts_with(\$secret, 'sk_test_')", $src);
+    }
+
+    public function testDoctorCallsPaymentCheck(): void
+    {
+        $src = self::methodSource('anvildev\booked\console\controllers\DoctorController', 'actionIndex');
+        $this->assertStringContainsString('checkPayments($settings)', $src);
+    }
+
+    public function testReconcileIsDirectModeOnly(): void
+    {
+        $src = self::methodSource('anvildev\booked\console\controllers\PaymentsController', 'actionReconcile');
+        $this->assertStringContainsString('PAYMENT_MODE_DIRECT', $src);
+    }
+
+    public function testReconcileTargetsNonFinalizedAndUsesIdempotentPath(): void
+    {
+        $src = self::methodSource('anvildev\booked\console\controllers\PaymentsController', 'actionReconcile');
+        // Only non-finalized records are re-queried.
+        $this->assertStringContainsString("['not in', 'status'", $src);
+        $this->assertStringContainsString('STATUS_PAID', $src);
+        // Finalization routes through the same idempotent path as the webhook.
+        $this->assertStringContainsString('handleVerifiedPayment(', $src);
+        // Dry-run writes nothing.
+        $this->assertStringContainsString('$this->dryRun', $src);
+    }
+
+    public function testReconcileExposesDryRunAndSinceOptions(): void
+    {
+        $src = self::methodSource('anvildev\booked\console\controllers\PaymentsController', 'options');
+        $this->assertStringContainsString('dryRun', $src);
+        $this->assertStringContainsString('since', $src);
+    }
+}


### PR DESCRIPTION
Final slice of **M3 hardening** (epic #33). Two console/ops concerns grouped in one PR.

## #50 — Doctor payment-config checks
`booked/doctor` gains a **Direct Payments** section (direct mode only): Stripe secret/publishable keys present + well-formed (`sk_`/`pk_`, and a hard fail if a secret key is pasted into the publishable field), the webhook secret set (`whsec_` — without it payments never confirm), the gateway registered, the currency resolvable, and a warn when test/live keys don't match the environment (live+devMode, or test+production).

## #51 — `booked/payments/reconcile`
A safety net for missed/dropped webhooks. Re-queries each **non-finalized** payment record against the gateway; a payment the gateway reports paid is finalized through the **same idempotent path as the webhook** (`handleVerifiedPayment`) — never double-confirming. Options: `--dry-run` (report only), `--since=<days>` (default 7). Direct mode only; safe to re-run.

## Verified live (dev, direct mode)
- `booked/doctor` → "Direct Payments [enabled]" with all checks passing (secret/publishable/webhook-secret set, gateway registered, currency USD).
- `booked/payments/reconcile --dry-run` → "No non-finalized payments to reconcile."
- Real run: inserted a `pending` record for an actually-captured Stripe intent (a simulated missed webhook) → reconcile reported "confirmed from gateway" and flipped it to `paid`.

## Tests
`PaymentOpsTest` — Doctor direct-mode guard + key/webhook-secret shape validation + test/live matching + wiring; reconcile direct-mode guard, non-finalized targeting, idempotent-path finalization, dry-run, and `--dry-run`/`--since` options. Full gate green (2737 tests; only the 2 pre-existing TZ failures). ECS + PHPStan clean.

Closes #50
Closes #51