### PR TITLE
[M4] Direct-payments setup + troubleshooting docs (#56)

### DIFF
--- a/docs/payments-setup.md
+++ b/docs/payments-setup.md
@@ -1,0 +1,166 @@
+# Direct payments (Stripe)
+
+Booked can take **paid bookings through Stripe with no Craft Commerce dependency**.
+A booking with a price is created as *pending*, the customer pays in-page with
+Stripe's Payment Element, and the booking is confirmed by a verified Stripe
+webhook. This guide covers setup, testing, and troubleshooting.
+
+> Booked also supports a **Commerce** payment mode (cart → checkout → order). This
+> guide is for the **direct** (Commerce-free) mode.
+
+---
+
+## 1. Payment modes
+
+Set the mode in **Settings → Payments** (or in config):
+
+| Mode | Behaviour |
+|------|-----------|
+| `none` | Bookings are free; no payment is taken. |
+| `direct` | Native Stripe checkout, no Commerce. **This guide.** |
+| `commerce` | Payment runs through Craft Commerce. |
+
+A service (or event date) with a **price** is what triggers payment. Free
+services always confirm immediately, regardless of mode.
+
+---
+
+## 2. Stripe keys
+
+From your [Stripe dashboard](https://dashboard.stripe.com/apikeys), copy your
+**publishable key** (`pk_…`) and **secret key** (`sk_…`) into
+**Settings → Payments**.
+
+Store them as environment variables and reference them, so secrets never live in
+project config or the database:
+
+```bash
+# .env
+STRIPE_PUBLISHABLE_KEY=pk_test_xxx
+STRIPE_SECRET_KEY=sk_test_xxx
+STRIPE_WEBHOOK_SECRET=whsec_xxx
+```
+
+Then enter `$STRIPE_PUBLISHABLE_KEY`, `$STRIPE_SECRET_KEY`, and
+`$STRIPE_WEBHOOK_SECRET` in the settings fields.
+
+Use **test** keys (`sk_test_…`/`pk_test_…`) in development and **live** keys in
+production. Booked's health check warns when they don't match the environment
+(see §7).
+
+---
+
+## 3. Webhook (required)
+
+The webhook is the **source of truth** — a booking is confirmed when Stripe
+tells Booked the payment succeeded. Without it, payments never confirm.
+
+1. In Stripe → **Developers → Webhooks → Add endpoint**, set the URL to:
+
+   ```
+   https://your-site.example/booked/api/v1/payment/webhook/stripe
+   ```
+
+2. Subscribe to at least these events:
+   - `payment_intent.succeeded`
+   - `charge.refunded` *(so refunds issued in the Stripe dashboard sync back to Booked)*
+
+3. Copy the endpoint's **signing secret** (`whsec_…`) into
+   **Settings → Payments → Stripe webhook secret** (as `$STRIPE_WEBHOOK_SECRET`).
+
+Booked verifies every webhook's signature and ignores unsigned or replayed
+events.
+
+### Testing the webhook locally
+
+Use the [Stripe CLI](https://stripe.com/docs/stripe-cli):
+
+```bash
+stripe listen --forward-to https://your-site.ddev.site/booked/api/v1/payment/webhook/stripe
+```
+
+`stripe listen` prints a `whsec_…` secret — put that in your settings while
+testing.
+
+---
+
+## 4. Content Security Policy
+
+Stripe's Payment Element loads `js.stripe.com` and renders card fields in
+Stripe-hosted iframes. If your site sends a strict CSP, **allow Stripe** on
+pages that show the booking wizard:
+
+```
+script-src  https://js.stripe.com;
+frame-src   https://js.stripe.com https://hooks.stripe.com;
+connect-src https://api.stripe.com;
+```
+
+Commerce and free bookings need none of this — only direct-payment pages load
+Stripe.
+
+---
+
+## 5. Currency, refunds, and abandoned checkouts
+
+- **Currency** — set **Settings → Payments → Currency** (install-wide). `auto`
+  falls back to Commerce's primary currency if present, else USD.
+- **Refund policy** — the same time-based refund policy (per service / event
+  date, or the install default) governs how much of a payment can be refunded.
+  Refunds are issued from the **booking's edit screen** by anyone with the
+  *Issue refunds* permission, or synced automatically if issued in the Stripe
+  dashboard.
+- **Pending-payment TTL** — a booking whose checkout is abandoned is cancelled
+  after `pendingPaymentTtlMinutes` (default 30), freeing the slot. Adjust it in
+  **Settings → Payments**.
+
+---
+
+## 6. Testing a payment
+
+With test keys and the webhook running, book a paid service and pay with a
+[Stripe test card](https://stripe.com/docs/testing):
+
+| Card | Result |
+|------|--------|
+| `4242 4242 4242 4242` | Succeeds |
+| `4000 0025 0000 3155` | Requires 3-D Secure authentication |
+| `4000 0000 0000 9995` | Declined (insufficient funds) |
+
+Any future expiry, any CVC, any postal code. After a successful payment the
+booking flips from *pending* to *confirmed*.
+
+---
+
+## 7. Operations & troubleshooting
+
+**Check your configuration:**
+
+```bash
+php craft booked/doctor
+```
+
+In direct mode this reports on your keys, the webhook secret, the registered
+gateway, and the resolved currency — and warns about live/test-vs-environment
+mismatches.
+
+**Reconcile after a missed webhook:**
+
+```bash
+php craft booked/payments/reconcile            # confirm any paid-but-pending records
+php craft booked/payments/reconcile --dry-run  # report only, change nothing
+php craft booked/payments/reconcile --since=30 # look back 30 days (default 7)
+```
+
+This re-queries Stripe for every non-finalized payment and confirms any that
+Stripe reports as paid — a safety net if a webhook was dropped.
+
+**Common issues**
+
+| Symptom | Likely cause |
+|---------|--------------|
+| Payment succeeds at Stripe but the booking stays *pending* | Webhook not configured, or the wrong/blank **webhook secret**. Check §3 and run `reconcile`. |
+| Card fields don't render | CSP is blocking `js.stripe.com` (see §4), or the publishable key is missing/wrong. |
+| "Payment is currently unavailable" | Secret key missing/invalid, or the Stripe gateway isn't reachable. Run `booked/doctor`. |
+| No real charges in production | **Test** keys are still configured. `booked/doctor` warns about this. |
+| A refund in Stripe isn't reflected in Booked | Subscribe the webhook to `charge.refunded` (§3). |


### PR DESCRIPTION
End-user documentation for direct (Commerce-free) Stripe payments: `docs/payments-setup.md`.

Covers payment modes, Stripe keys (as `$ENV` refs), the webhook endpoint + signing secret (incl. `stripe listen` for local testing), the **CSP allowances** for js.stripe.com, currency / refund policy / pending-payment TTL, testing with Stripe test cards, and an operations/troubleshooting section built around `booked/doctor` and `booked/payments/reconcile`.

Grounded in the actual routes (`booked/api/v1/payment/webhook/stripe`), settings (`paymentMode`, `stripe*`, `pendingPaymentTtlMinutes`), and console commands as implemented in M1–M3.

Closes #56