### PR TITLE
Add Playwright E2E for direct-payment browser checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,8 @@
 .phpstan/
 .claude/worktrees/
 coverage/
+
+# Playwright
+test-results/
+playwright-report/
+/node_modules/@playwright/

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,46 @@
+# Browser E2E — direct-payment checkout
+
+A [Playwright](https://playwright.dev) test that drives the **real booking wizard
+in a browser** through to the **Stripe Payment Element**, pays with a test card,
+and asserts the booking confirms. It covers the one layer the PHP/JS unit tests
+and the server-side smoke can't: the actual Stripe Element rendering, card entry,
+and 3-D-Secure-free confirmation.
+
+## Prerequisites
+
+1. A booking page **in `direct` payment mode** with Stripe **test** keys
+   (`pk_test_…` / `sk_test_…`) configured — see `docs/payments-setup.md`.
+2. A service with a **price** so the flow requires payment.
+3. Recommended: `stripe listen` forwarding to the webhook so the booking confirms
+   the way it does in production. (Without it, the wizard's client confirm-poll
+   still finalizes the booking, so the test passes either way.)
+
+   ```bash
+   stripe listen --forward-to https://your-site/booked/api/v1/payment/webhook/stripe
+   ```
+
+## Run
+
+From the plugin root:
+
+```bash
+npm install -D @playwright/test
+npx playwright install chromium
+
+BOOKED_E2E_URL="https://your-site/wizard/service" \
+  npx playwright test -c tests/e2e/playwright.config.ts
+```
+
+Add `--headed` to watch it, or `--debug` to step through.
+
+Test card: `4242 4242 4242 4242`, any future expiry, any CVC, any ZIP. See
+[Stripe test cards](https://stripe.com/docs/testing) for decline / 3-D-Secure
+variants.
+
+## Note on the Stripe iframe selectors
+
+The spec locates the Payment Element's card fields by placeholder inside Stripe's
+iframe. Stripe occasionally changes the Element's DOM/layout (single vs. split
+fields, field labels). If the card fields don't fill, run with `--headed` and
+adjust the `frameLocator` / `getByPlaceholder` calls in `booking-payment.spec.ts`
+to match what Stripe renders for your account.

--- a/tests/e2e/booking-payment.spec.ts
+++ b/tests/e2e/booking-payment.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * End-to-end browser smoke of the direct-payment booking flow: drive the vanilla
+ * wizard through to the Stripe Payment Element, pay with a test card, and assert
+ * the booking confirms. This is the one layer the headless/server smoke can't
+ * cover — the real Stripe Element rendering + card entry + confirmation.
+ *
+ * Prerequisites (see tests/e2e/README.md):
+ *   - A booking page in **direct** payment mode with Stripe **test** keys.
+ *   - BOOKED_E2E_URL pointing at that page (defaults to the DDEV dev site).
+ *   - Ideally `stripe listen` forwarding to the webhook; the client confirm-poll
+ *     is the fallback, so success still shows without it.
+ */
+
+const BOOKING_URL =
+  process.env.BOOKED_E2E_URL || 'https://craft-plugin-dev.ddev.site/wizard/service';
+
+/** Run `action` only if the given wizard step is currently visible (steps are conditional). */
+async function ifStepVisible(page: Page, stepId: string, action: () => Promise<void>) {
+  const region = page.locator(`[data-booked-step="${stepId}"]`);
+  if (await region.isVisible().catch(() => false)) {
+    await action();
+  }
+}
+
+test('direct payment: wizard → Stripe Element → booking confirmed', async ({ page }) => {
+  await page.goto(BOOKING_URL);
+
+  // 1. Service
+  const serviceStep = page.locator('[data-booked-step="service"]');
+  await expect(serviceStep).toBeVisible();
+  await serviceStep.locator('[data-booked-action="select-service"]').first().click();
+  await serviceStep.locator('[data-booked-action="next"]').click();
+
+  // 2. Optional steps — pick the first option (if any) and advance.
+  for (const step of ['extras', 'location', 'employee']) {
+    await ifStepVisible(page, step, async () => {
+      const region = page.locator(`[data-booked-step="${step}"]`);
+      const pick = region.locator('[data-booked-action^="select-"]').first();
+      if (await pick.isVisible().catch(() => false)) await pick.click();
+      await region.locator('[data-booked-action="next"]').click();
+    });
+  }
+
+  // 3. Date + time
+  const datetime = page.locator('[data-booked-step="datetime"]');
+  await expect(datetime).toBeVisible();
+  await page.locator('[data-booked-date]:not([aria-disabled="true"])').first().click();
+  await page.locator('[data-booked-slots] button:not([disabled])').first().click();
+  await datetime.locator('[data-booked-action="next"]').click();
+
+  // 4. Customer info
+  const info = page.locator('[data-booked-step="info"]');
+  await expect(info).toBeVisible();
+  await info.locator('[data-booked-field="name"]').fill('E2E Tester');
+  await info.locator('[data-booked-field="email"]').fill('e2e@example.com');
+  await info.locator('[data-booked-action="next"]').click();
+
+  // 5. Review → submit. Creates the *pending* booking and enters the payment step.
+  const review = page.locator('[data-booked-step="review"]');
+  await expect(review).toBeVisible();
+  await review.locator('[data-booked-action="submit"]').click();
+
+  // 6. Stripe Payment Element (rendered in a Stripe-hosted iframe). The Payment
+  //    Element combines fields; selectors may need adjusting for your Stripe
+  //    layout (see README). Test card: always-succeeds Visa.
+  const payment = page.locator('[data-booked-step="payment"]');
+  await expect(payment).toBeVisible();
+
+  const stripe = page
+    .frameLocator('iframe[title="Secure payment input frame"], iframe[name^="__privateStripeFrame"]')
+    .first();
+  await stripe.getByPlaceholder('Card number').fill('4242 4242 4242 4242');
+  await stripe.getByPlaceholder(/MM ?\/ ?YY/).fill('12 / 34');
+  await stripe.getByPlaceholder('CVC').fill('123');
+  const zip = stripe.getByPlaceholder(/ZIP|Postal/);
+  if (await zip.isVisible().catch(() => false)) await zip.fill('12345');
+
+  await payment.locator('[data-booked-action="pay"]').click();
+
+  // 7. Confirmed — the success step shows once the payment is confirmed (webhook,
+  //    or the client confirm-poll as fallback).
+  await expect(page.locator('[data-booked-step="success"]')).toBeVisible({ timeout: 30_000 });
+  await expect(page.locator('[data-booked-summary="status"]')).not.toBeEmpty();
+});

--- a/tests/e2e/booking-payment.spec.ts
+++ b/tests/e2e/booking-payment.spec.ts
@@ -16,6 +16,9 @@ import { test, expect, type Page } from '@playwright/test';
 const BOOKING_URL =
   process.env.BOOKED_E2E_URL || 'https://craft-plugin-dev.ddev.site/wizard/service';
 
+// Optionally target a specific service card (by data-booked-id); else the first.
+const SERVICE_ID = process.env.BOOKED_E2E_SERVICE_ID || '';
+
 /** Run `action` only if the given wizard step is currently visible (steps are conditional). */
 async function ifStepVisible(page: Page, stepId: string, action: () => Promise<void>) {
   const region = page.locator(`[data-booked-step="${stepId}"]`);
@@ -27,11 +30,17 @@ async function ifStepVisible(page: Page, stepId: string, action: () => Promise<v
 test('direct payment: wizard → Stripe Element → booking confirmed', async ({ page }) => {
   await page.goto(BOOKING_URL);
 
-  // 1. Service
-  const serviceStep = page.locator('[data-booked-step="service"]');
-  await expect(serviceStep).toBeVisible();
-  await serviceStep.locator('[data-booked-action="select-service"]').first().click();
-  await serviceStep.locator('[data-booked-action="next"]').click();
+  // 1. Service — skipped when the page preselects one. Otherwise pick the
+  //    configured service (BOOKED_E2E_SERVICE_ID) or the first card. Going through
+  //    the real service step is what triggers the availability fetch.
+  await ifStepVisible(page, 'service', async () => {
+    const serviceStep = page.locator('[data-booked-step="service"]');
+    const card = SERVICE_ID
+      ? serviceStep.locator(`[data-booked-action="select-service"][data-booked-id="${SERVICE_ID}"]`)
+      : serviceStep.locator('[data-booked-action="select-service"]').first();
+    await card.click();
+    await serviceStep.locator('[data-booked-action="next"]').click();
+  });
 
   // 2. Optional steps — pick the first option (if any) and advance.
   for (const step of ['extras', 'location', 'employee']) {
@@ -48,6 +57,8 @@ test('direct payment: wizard → Stripe Element → booking confirmed', async ({
   await expect(datetime).toBeVisible();
   await page.locator('[data-booked-date]:not([aria-disabled="true"])').first().click();
   await page.locator('[data-booked-slots] button:not([disabled])').first().click();
+  // Let the soft-lock request settle before advancing (submit sends its token).
+  await page.waitForTimeout(1500);
   await datetime.locator('[data-booked-action="next"]').click();
 
   // 4. Customer info
@@ -71,11 +82,17 @@ test('direct payment: wizard → Stripe Element → booking confirmed', async ({
   const stripe = page
     .frameLocator('iframe[title="Secure payment input frame"], iframe[name^="__privateStripeFrame"]')
     .first();
-  await stripe.getByPlaceholder('Card number').fill('4242 4242 4242 4242');
+  await stripe.getByPlaceholder('1234 1234 1234 1234').fill('4242424242424242');
   await stripe.getByPlaceholder(/MM ?\/ ?YY/).fill('12 / 34');
   await stripe.getByPlaceholder('CVC').fill('123');
   const zip = stripe.getByPlaceholder(/ZIP|Postal/);
   if (await zip.isVisible().catch(() => false)) await zip.fill('12345');
+  // Depending on country/config the Payment Element also requires a billing name
+  // (and sometimes email) — fill them when present, or confirmPayment 400s.
+  const fullName = stripe.getByPlaceholder(/Full name|Name on card/i);
+  if (await fullName.isVisible().catch(() => false)) await fullName.fill('E2E Tester');
+  const email = stripe.getByPlaceholder('you@example.com');
+  if (await email.isVisible().catch(() => false)) await email.fill('e2e@example.com');
 
   await payment.locator('[data-booked-action="pay"]').click();
 

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright config for the direct-payment browser E2E. Run from the plugin root:
+ *   BOOKED_E2E_URL=https://your-site/wizard/service npx playwright test -c tests/e2e/playwright.config.ts
+ */
+export default defineConfig({
+  testDir: '.',
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  fullyParallel: false,
+  retries: 0,
+  reporter: 'list',
+  use: {
+    baseURL: process.env.BOOKED_E2E_URL,
+    ignoreHTTPSErrors: true, // DDEV self-signed certs
+    headless: true,
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+});


### PR DESCRIPTION
The real-browser layer of the pre-release smoke: a Playwright test that drives the vanilla booking wizard through to the **Stripe Payment Element**, pays with a test card, and asserts the booking confirms.

## What
- `tests/e2e/booking-payment.spec.ts` — full wizard walk (service → optional steps → date/time → info → review → **submit** → Stripe Element → **success**), using the stable `data-booked-*` selectors and Stripe's iframe.
- `tests/e2e/playwright.config.ts` — chromium, `ignoreHTTPSErrors` for DDEV, screenshots/traces on failure, `BOOKED_E2E_URL` env.
- `tests/e2e/README.md` — prerequisites (direct mode + Stripe test keys + `stripe listen`), how to run, and a note on adjusting the Stripe iframe selectors if the Element DOM shifts.

## Why a separate spec
No browser-automation tool is available in the dev/CI harness that produced this, so this is authored to be **run locally / in CI** with `npx playwright test`. It complements the server-side smoke (below) which covers every backend path headlessly.

## Server-side E2E — verified live this session (Stripe test mode)
A scripted HTTP + Stripe-API smoke ran **10/10 green** against the dev site: `payment/create` → correct minor-unit amount → PaymentIntent paid → **webhook confirms the booking** → paid; bad token → 403; unsigned webhook → 400; dashboard refund → `refundedAmount` synced + `partiallyRefunded`. (GC, reconcile, and the Doctor payment checks were separately live-verified.)

Not picked up by vitest (globs only `src/web/js/**/*.test.js`).