### PR TITLE
docs: refresh feature list + drop Alpine.js references

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -2328,7 +2328,7 @@ The plugin fires the event with `wasPaid` and `shouldRefund` flags but does **no
 The booking wizard supports two Commerce submission modes:
 
 ```javascript
-// In the wizard's Alpine.js component
+// In the legacy wizard component (deprecated, removed in 2.0)
 async addToCart() {
     this.addToCartOnly = true;    // sends addToCart=1
     await this.submitBooking();   // redirects to cart

--- a/README.md
+++ b/README.md
@@ -18,11 +18,13 @@ A comprehensive booking and reservation management plugin for Craft CMS, designe
 - **Customer Booking Limits**: Configurable limits per service to prevent overbooking
 - **Customer Self-Service Portal**: Logged-in customers can view, manage, and cancel their bookings
 - **Multi-Site Support**: Localized services with propagation across multiple sites
+- **Framework-Free Booking Wizard**: A zero-dependency, CSP-safe multi-step booking wizard (no front-end framework required) that auto-selects and skips single-option steps to shorten the path to booking; plus dedicated event-booking and customer self-service flows
 
 ### Advanced Features
 - **Calendar Sync**: Two-way sync with Google Calendar and Microsoft Outlook
 - **Virtual Meetings**: Automatic Zoom, Google Meet, and Microsoft Teams meeting creation for online appointments
-- **Payment Integration**: Native Craft Commerce integration
+- **Payments**: Take paid bookings with **Stripe — no Craft Commerce required** (direct payments), or through **Craft Commerce**. Includes full and partial, policy-aware **refunds**, a Control-Panel payment status panel, and a Settings → Payments UI for the payment mode, Stripe keys, currency, and webhook endpoint
+- **Payments-Aware Reporting**: In direct mode, revenue reflects actually-captured amounts net of refunds; the bookings CSV export gains gateway, payment-status, and refunded columns
 - **Email Notifications**: Customizable email templates for confirmations, reminders, and cancellations
 - **SMS Notifications**: Twilio integration for booking confirmations, reminders, and cancellations
 - **Webhooks**: Send booking events to Zapier, n8n, Make, or custom endpoints with HMAC signing

--- a/docs/VANILLA_WIZARD.md
+++ b/docs/VANILLA_WIZARD.md
@@ -6,7 +6,7 @@ guide covers the three ways to use it — drop-in Twig, template customization,
 and fully headless — plus the public JS API and the `data-booked-*` contract.
 
 > Status: 1.3.0. `{% include 'booked/frontend/wizard' %}` renders the vanilla
-> wizard by default; the deprecated Alpine wizard is restored with the
+> wizard by default; the deprecated legacy wizard is restored with the
 > `legacyWizard` setting (removed in 2.0).
 
 ---
@@ -132,16 +132,16 @@ bookings, whose server-side seat lock is best-effort, submit directly from
 
 ---
 
-## 5. Migrating from the Alpine wizard
+## 5. Migrating from the legacy wizard
 
 - The include path and documented config variables are unchanged — existing
   drop-in usage keeps working, now rendering the vanilla wizard.
 - Need the old wizard while you migrate a heavy customization? Enable the
   **`legacyWizard`** setting (or `{% include 'booked/frontend/wizard' with
   { legacyWizard: true } %}`). It's deprecated and removed in 2.0.
-- Forked the old Alpine wizard? The structure maps to **Twig template overrides
-  + JS events**: markup you edited in `x-*` attributes becomes `data-booked-*`
+- Forked the old legacy wizard? The structure maps to **Twig template overrides
+  + JS events**: markup you edited in its directive attributes becomes `data-booked-*`
   markup; logic you patched becomes an event listener on the core. There is no
-  Alpine to fork — behavior lives in the core, markup in your Twig.
+  framework to fork — behavior lives in the core, markup in your Twig.
 - The REST endpoints the wizard calls are now the versioned, documented
   `/booked/api/v1/…` surface; pin to it for custom frontends.

--- a/docs/WIZARD_CORE_DESIGN.md
+++ b/docs/WIZARD_CORE_DESIGN.md
@@ -13,7 +13,7 @@ This design covers **both** the booking flow and the event flow (plus event-mana
 The core is the semver'd, zero-dependency brain that any frontend drives:
 
 1. **Zero runtime dependencies**, no `eval`/`new Function`, no DOM assumptions. Runs headless (Node/tests) or behind any renderer.
-2. **Explicit, testable state machine** — replaces the previous Alpine implementation's implicit reactive state and the hand-written `nextStep` / `getPreviousStep` / `shouldSkipEmployeeStep` split that was the source of back-nav and lock-expiry edge-case bugs.
+2. **Explicit, testable state machine** — replaces the previous implementation's implicit reactive state and the hand-written `nextStep` / `getPreviousStep` / `shouldSkipEmployeeStep` split that was the source of back-nav and lock-expiry edge-case bugs.
 3. **One flow engine, two flows** — booking and event flows are *data* (step definitions + endpoint bindings), not forked code.
 4. **Events over overrides** — every meaningful transition emits; the renderer is just the first consumer, which proves the headless contract.
 5. **First-class soft-lock with a hold timer** — the current wizard has *no* client-side countdown and only discovers an expired lock at submit. The core owns the timer and emits `lock:expiring` / `lock:expired`.
@@ -55,7 +55,7 @@ Budget: core + UI gzipped **< 25 KB** (PRD success metric). Core alone is expect
 
 ## 3. The state machine
 
-Two dimensions kept deliberately separate — conflating them is what made the previous Alpine version fragile:
+Two dimensions kept deliberately separate — conflating them is what made the previous wizard version fragile:
 
 - **Lifecycle state** — *what phase the booking is in* (finite, guarded).
 - **Step cursor** — *which visible step the user is on* within the browsing phase (derived from the flow definition, never hand-maintained).
@@ -356,4 +356,4 @@ A **headless integration script** (the M1 exit demo) drives `create()` → `sele
 | `config.messages` / `stepAnnouncements` + Twig `|t` split | `i18n.js` table with English fallbacks |
 | `handleBookingResult` Commerce redirect | `submit()` → `payment:redirect` seam |
 | `window.csrfTokenName/Value` inline globals | `config.api.csrf` (no inline globals; CSP-safe) |
-| Alpine `new Function` directive evaluation | *(eliminated — logic lives in core getters/methods)* |
+| Legacy `new Function` directive evaluation | *(eliminated — logic lives in core getters/methods)* |


### PR DESCRIPTION
Refreshes the plugin's long description and scrubs Alpine.js from the docs.

## README (long description)
- **Payments** now describes the 1.4 **direct/Commerce-free Stripe** path (with refunds, the CP payment panel, and the Settings → Payments UI) alongside Craft Commerce — previously it only said "Native Craft Commerce integration".
- Added **Payments-Aware Reporting** and the **Framework-Free Booking Wizard** (zero-dependency, CSP-safe, auto-skips single-option steps).

## Alpine.js scrub
Per request, the docs no longer present Alpine.js. Reframed `Alpine wizard` → `legacy wizard` and removed Alpine-implementation mentions across `DEVELOPER_GUIDE.md`, `docs/VANILLA_WIZARD.md`, and `docs/WIZARD_CORE_DESIGN.md`. Kept an honest note that the **legacy wizard is deprecated and removed in 2.0** (it still ships in code until then). `CHANGELOG.md` history is left untouched.

No code changes.