### PR TITLE
Hold only requested seats on group-event soft locks

### DIFF
--- a/src/controllers/SlotController.php
+++ b/src/controllers/SlotController.php
@@ -513,6 +513,7 @@ class SlotController extends Controller
         }
 
         $durationMinutes = Booked::getInstance()->getSettings()->softLockDurationMinutes ?? 5;
+        $quantity = max(1, (int)(Craft::$app->request->getBodyParam('quantity') ?? 1));
 
         $token = Booked::getInstance()->getSoftLock()->createLock([
             'date' => $eventDate->eventDate,
@@ -521,6 +522,8 @@ class SlotController extends Controller
             'serviceId' => 0,
             'employeeId' => null,
             'locationId' => $eventDate->locationId,
+            'quantity' => $quantity,
+            'capacity' => $eventDate->capacity,
         ], $durationMinutes);
 
         if ($token === false) {


### PR DESCRIPTION
Follow-up to the B5 fix in v1.4.3 (logged as W05).

`actionCreateEventLock()` passed neither quantity nor capacity, so `SoftLockService::isLocked()` fell to its `exists()` branch and an event hold became **exclusive**. On a 50-seat event with 38 free, customer A's hold refused customer B ("This time slot is temporarily reserved") while dozens of seats remained — blocking group-event checkout.

**Fix:** read the requested `quantity` (already sent by the client) and pass `$eventDate->capacity`, putting event locks on the same seat-counting path the slot locks use.

**Verified (live):** two concurrent holds on event 9517 (cap 50) now both succeed.

Known limitation left open: `booked_soft_locks` has no `eventDateId`, so two events sharing a date, time and location would share a lock key. No such pair exists to reproduce it; a fix needs a schema column.