### PR TITLE
Count event holds against remaining capacity; fix {quantity} placeholder

### DIFF
--- a/src/controllers/SlotController.php
+++ b/src/controllers/SlotController.php
@@ -523,7 +523,7 @@ class SlotController extends Controller
             'employeeId' => null,
             'locationId' => $eventDate->locationId,
             'quantity' => $quantity,
-            'capacity' => $eventDate->capacity,
+            'capacity' => $eventDate->getRemainingCapacity(),
         ], $durationMinutes);
 
         if ($token === false) {

--- a/src/services/BookingService.php
+++ b/src/services/BookingService.php
@@ -632,7 +632,7 @@ class BookingService extends Component
         }
 
         if ($remainingCapacity !== null && $quantity > $remainingCapacity) {
-            throw new BookingValidationException(Craft::t('booked', 'booking.quantityExceedsCapacity', ['capacity' => $remainingCapacity]));
+            throw new BookingValidationException(Craft::t('booked', 'booking.quantityExceedsCapacity', ['quantity' => $quantity, 'capacity' => $remainingCapacity]));
         }
     }
 


### PR DESCRIPTION
Two smaller issues surfaced verifying the v1.4.4 group-event fix (B5a, B5c).

**B5a — holds counted against total, not remaining, capacity.** `actionCreateEventLock()` passed `$eventDate->capacity` raw, so confirmed bookings were invisible to the hold ledger: a 50-seat event with 12 booked (38 free) granted 39 seats of holds; a 2-seat-left event granted a 5-seat hold. Now passes `getRemainingCapacity()`. Verified live on event 9515 (2 left): a 5-seat hold is refused, a 2-seat hold succeeds, and the next seat is refused.

**B5c — uninterpolated placeholder.** `booking.quantityExceedsCapacity` reads "The requested quantity ({quantity}) exceeds the remaining capacity (2)." — `{quantity}` was never passed. Now interpolated.

Neither could oversell (the booking-time capacity re-check is the safety net); these tighten the hold ledger and fix a customer-facing string.

Still open (needs a schema column, no fix here): B5b — co-located events share a lock key because `booked_soft_locks` has no `eventDateId`.