### PR TITLE
Release 1.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.4.5 - 2026-07-29
+
+### Fixed
+- **Event holds now count against remaining seats, not total capacity.** Existing confirmed bookings were invisible to the hold ledger, so a nearly-full event could still hand out holds for seats that were already taken (e.g. a 2-seats-left event granting a 5-seat hold). Holds are now capped at the remaining capacity. The booking-time capacity re-check already prevented any actual oversell; this tightens the holds themselves.
+- **The "quantity exceeds capacity" message now shows the requested quantity.** The `{quantity}` placeholder was never filled in, so the message read "The requested quantity () exceeds the remaining capacity (2)."
+
 ## 1.4.4 - 2026-07-29
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "anvildev/craft-booked",
     "description": "A comprehensive booking system for Craft CMS",
     "type": "craft-plugin",
-    "version": "1.4.4",
+    "version": "1.4.5",
     "keywords": [
         "craft",
         "cms",


### PR DESCRIPTION
Cuts **1.4.5** — patch release with the event-hold remaining-capacity fix and the {quantity} message fix (#83). No schema changes.