### PR TITLE
Make the default branch green again

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,13 +14,6 @@ parameters:
         - ../../vendor/craftcms/cms/bootstrap/console.php
         - stubs/phpstan-bootstrap.php
     ignoreErrors:
-        # Optional stimmt/craft-mcp integration (see composer.json "suggest") — the package and
-        # its mcp/sdk attributes are not installed in this repo; src/mcp tools are only ever
-        # loaded by craft-mcp's registry when it is present (registration is class_exists-guarded).
-        - '#Attribute class Mcp\\Capability\\Attribute\\\w+ does not exist#'
-        - '#Attribute class stimmt\\craft\\Mcp\\attributes\\McpToolMeta does not exist#'
-        - '#on an unknown class stimmt\\craft\\Mcp\\#'
-        - '#has invalid type stimmt\\craft\\Mcp\\events\\RegisterToolsEvent#'
         # Common patterns for Craft CMS plugins
         - '#Cannot access offset .+ on mixed#'
         - '#Cannot cast mixed to#'

--- a/src/elements/Reservation.php
+++ b/src/elements/Reservation.php
@@ -21,10 +21,20 @@ use craft\enums\Color;
 use craft\helpers\Html;
 use craft\helpers\UrlHelper;
 
-if (interface_exists(\craft\commerce\base\PurchasableInterface::class)) {
-    class_alias(\craft\commerce\base\PurchasableInterface::class, 'anvildev\booked\elements\_ReservationPurchasable');
-} else {
-    class_alias(\anvildev\booked\contracts\PurchasableShim::class, 'anvildev\booked\elements\_ReservationPurchasable');
+// Commerce is optional, so the interface Reservation implements is aliased to
+// the real PurchasableInterface when Commerce is installed and to a local shim
+// when it is not.
+//
+// The guard makes the alias idempotent. class_alias() at file scope throws
+// "Cannot declare interface … because the name is already in use" if this file
+// is evaluated twice in one process — which PHPStan's bootstrap does, and which
+// surfaced as six warnings that only appeared on a cold result cache.
+if (!interface_exists('anvildev\booked\elements\_ReservationPurchasable', false)) {
+    if (interface_exists(\craft\commerce\base\PurchasableInterface::class)) {
+        class_alias(\craft\commerce\base\PurchasableInterface::class, 'anvildev\booked\elements\_ReservationPurchasable');
+    } else {
+        class_alias(\anvildev\booked\contracts\PurchasableShim::class, 'anvildev\booked\elements\_ReservationPurchasable');
+    }
 }
 
 class Reservation extends Element implements _ReservationPurchasable, ReservationInterface

--- a/storage/logs/console-2026-08-03.log
+++ b/storage/logs/console-2026-08-03.log
@@ -1,0 +1,16 @@
+2026-08-03 19:12:33 [console.ERROR] [craft\db\Connection::open] SQLSTATE[HY000] [2002] No such file or directory {"memory":19554832} 
+2026-08-03 19:12:33 [console.ERROR] [craft\db\Connection::open] SQLSTATE[HY000] [2002] No such file or directory {"memory":19555264} 
+2026-08-03 19:12:34 [console.ERROR] [craft\db\Connection::open] SQLSTATE[HY000] [2002] No such file or directory {"memory":19554832} 
+2026-08-03 19:12:34 [console.ERROR] [craft\db\Connection::open] SQLSTATE[HY000] [2002] No such file or directory {"memory":19555264} 
+2026-08-03 19:12:35 [console.ERROR] [craft\db\Connection::open] SQLSTATE[HY000] [2002] No such file or directory {"memory":19554832} 
+2026-08-03 19:12:35 [console.ERROR] [craft\db\Connection::open] SQLSTATE[HY000] [2002] No such file or directory {"memory":19555264} 
+2026-08-03 19:12:37 [console.ERROR] [craft\db\Connection::open] SQLSTATE[HY000] [2002] No such file or directory {"memory":19554832} 
+2026-08-03 19:12:37 [console.ERROR] [craft\db\Connection::open] SQLSTATE[HY000] [2002] No such file or directory {"memory":19555264} 
+2026-08-03 19:12:41 [console.ERROR] [craft\db\Connection::open] SQLSTATE[HY000] [2002] No such file or directory {"memory":19554832} 
+2026-08-03 19:12:41 [console.ERROR] [craft\db\Connection::open] SQLSTATE[HY000] [2002] No such file or directory {"memory":19555264} 
+2026-08-03 19:12:43 [console.ERROR] [craft\db\Connection::open] SQLSTATE[HY000] [2002] No such file or directory {"memory":19554832} 
+2026-08-03 19:12:43 [console.ERROR] [craft\db\Connection::open] SQLSTATE[HY000] [2002] No such file or directory {"memory":19555264} 
+2026-08-03 19:12:44 [console.ERROR] [craft\db\Connection::open] SQLSTATE[HY000] [2002] No such file or directory {"memory":19554832} 
+2026-08-03 19:12:44 [console.ERROR] [craft\db\Connection::open] SQLSTATE[HY000] [2002] No such file or directory {"memory":19555264} 
+2026-08-03 19:12:45 [console.ERROR] [craft\db\Connection::open] SQLSTATE[HY000] [2002] No such file or directory {"memory":25180608} 
+2026-08-03 19:12:45 [console.ERROR] [craft\db\Connection::open] SQLSTATE[HY000] [2002] No such file or directory {"memory":25181040} 

--- a/tests/Unit/Controllers/ControllerSourceTest.php
+++ b/tests/Unit/Controllers/ControllerSourceTest.php
@@ -132,42 +132,58 @@ class ControllerSourceTest extends TestCase
     {
         $source = $this->controllerSource($controllerFile);
 
-        if (empty($expectedActions)) {
-            $this->assertMatchesRegularExpression(
-                '/\$allowAnonymous\s*=\s*\[\s*\]/',
-                $source,
-                "{$controllerFile} should have empty \$allowAnonymous array"
-            );
-            return;
-        }
+        // Compare the whole declared set, not just "are the expected ones
+        // present". This is the list of actions reachable with no authentication
+        // at all, so an *extra* entry matters as much as a missing one — and the
+        // old containment check would have passed with any number of them.
+        $this->assertSame(
+            1,
+            preg_match('/\$allowAnonymous\s*=\s*(\[[^\]]*\])/', $source, $m),
+            "{$controllerFile} should declare \$allowAnonymous",
+        );
 
-        foreach ($expectedActions as $action) {
-            $this->assertStringContainsString(
-                "'{$action}'",
-                $source,
-                "'{$action}' should be in \$allowAnonymous for {$controllerFile}"
-            );
-        }
+        preg_match_all("/'([a-z0-9\-]+)'/i", $m[1], $found);
+        $declared = $found[1];
+        sort($declared);
+        sort($expectedActions);
+
+        $this->assertSame(
+            $expectedActions,
+            $declared,
+            "{$controllerFile} allows anonymous access to a different set of actions than expected",
+        );
     }
 
     public static function allowAnonymousProvider(): array
     {
         return [
             'BookingController' => ['BookingController.php', ['create-booking']],
+            // Availability and soft-lock endpoints the public booking wizard
+            // calls before anyone has identified themselves.
             'SlotController' => ['SlotController.php', [
-                'get-available-slots', 'get-availability-calendar', 'get-event-dates', 'create-lock', 'release-lock',
+                'get-available-slots', 'get-availability-calendar', 'get-available-dates',
+                'get-valid-end-dates', 'get-event-dates', 'get-range-capacity',
+                'create-lock', 'create-event-lock', 'create-multi-day-lock',
+                'extend-lock', 'release-lock',
             ]],
-            'WaitlistController' => ['WaitlistController.php', ['join-waitlist']],
+            'WaitlistController' => ['WaitlistController.php', ['join-waitlist', 'join-event-waitlist']],
             'BookingDataController' => ['BookingDataController.php', [
                 'get-services', 'get-service-extras', 'get-employees', 'get-commerce-settings',
             ]],
+            // Reached from the link in a confirmation email, so the visitor is
+            // not logged in. Each one authenticates on the reservation's
+            // confirmation token with hash_equals() and audits a failure.
             'BookingManagementController' => ['BookingManagementController.php', [
                 'manage-booking', 'cancel-booking-by-token', 'download-ics',
+                'increase-quantity', 'reduce-quantity',
             ]],
             'CalendarConnectController' => ['CalendarConnectController.php', [
                 'connect', 'callback', 'success', 'error',
             ]],
-            'AccountController empty' => ['AccountController.php', []],
+            // current-user is deliberately anonymous: it answers
+            // {loggedIn: false} for a guest and only ever returns the requesting
+            // user's own record, so the wizard can prefill without a 403.
+            'AccountController' => ['AccountController.php', ['current-user']],
         ];
     }
 

--- a/tests/Unit/Elements/EventDateSoftDeleteTest.php
+++ b/tests/Unit/Elements/EventDateSoftDeleteTest.php
@@ -56,11 +56,17 @@ class EventDateSoftDeleteTest extends TestCase
     public function testSoftDeleteSetsValidDateTimeString(): void
     {
         $eventDate = $this->makeEventDate();
-        $before = new \DateTime();
+        // softDelete() stores UTC without a zone marker, per Craft's DB
+        // convention. Parsing that naive string with new DateTime() would read it
+        // in the server's local zone, putting it hours behind $before — which is
+        // why this failed by exactly Zurich's offset and would have passed only
+        // on a UTC machine.
+        $utc = new \DateTimeZone('UTC');
+        $before = new \DateTime('now', $utc);
         $eventDate->softDelete();
-        $after = new \DateTime();
+        $after = new \DateTime('now', $utc);
 
-        $deletedAt = new \DateTime($eventDate->deletedAt);
+        $deletedAt = new \DateTime($eventDate->deletedAt, $utc);
         $this->assertGreaterThanOrEqual($before->getTimestamp(), $deletedAt->getTimestamp());
         $this->assertLessThanOrEqual($after->getTimestamp(), $deletedAt->getTimestamp());
     }

--- a/tests/Unit/Elements/ServiceSoftDeleteTest.php
+++ b/tests/Unit/Elements/ServiceSoftDeleteTest.php
@@ -50,11 +50,17 @@ class ServiceSoftDeleteTest extends TestCase
     public function testSoftDeleteSetsValidDateTimeString(): void
     {
         $service = $this->makeService();
-        $before = new \DateTime();
+        // softDelete() stores UTC without a zone marker, per Craft's DB
+        // convention. Parsing that naive string with new DateTime() would read it
+        // in the server's local zone, putting it hours behind $before — which is
+        // why this failed by exactly Zurich's offset and would have passed only
+        // on a UTC machine.
+        $utc = new \DateTimeZone('UTC');
+        $before = new \DateTime('now', $utc);
         $service->softDelete();
-        $after = new \DateTime();
+        $after = new \DateTime('now', $utc);
 
-        $deletedAt = new \DateTime($service->deletedAt);
+        $deletedAt = new \DateTime($service->deletedAt, $utc);
         $this->assertGreaterThanOrEqual($before->getTimestamp(), $deletedAt->getTimestamp());
         $this->assertLessThanOrEqual($after->getTimestamp(), $deletedAt->getTimestamp());
     }


### PR DESCRIPTION
`composer check` and `composer test` were both red on `main`. **Booked has no CI workflow** — only `dependabot.yml` — so nothing has ever run this gate, which is how it drifted.

## PHPStan: four unmatched ignore patterns

The patterns weren't stale — **the comment beside them was**. It claims craft-mcp "is not installed in this repo", but `phpstan.neon` bootstraps `../../vendor/autoload.php`, the *monorepo's* vendor, where `stimmt/craft-mcp` **is** present. So the attributes resolve, no errors are reported, and the ignores match nothing. Removed — which also means the MCP tools are now genuinely analysed instead of blanket-ignored.

I first tried repointing PHPStan at the plugin's own vendor (the fix Slots got). That produces **45** errors here, because Booked soft-depends on Commerce, Google, Twilio and microsoft-graph, which only the monorepo vendor has. Reverted.

## A warm cache was hiding six real warnings

Removing the ignores surfaced six warnings — but only on a **cold** cache:

```
composer phpstan                    → [OK] No errors
rm -rf .phpstan && composer phpstan → [ERROR] Found 6 errors
```

All six: `Cannot declare interface _ReservationPurchasable, because the name is already in use`. `Reservation.php` aliases its Purchasable interface at file scope, and `class_alias()` throws when the file is evaluated twice in one process — which PHPStan's bootstrap does. The alias is now idempotent, which also protects the runtime.

## The allowAnonymous test couldn't see additions

It only asserted the expected actions were *present*, so any number of extra anonymous actions passed. Since this list is precisely "what is reachable with no authentication", that's the wrong direction to be lenient in. Made exact — and it immediately found three controllers that had grown since the list was written:

| Controller | Was | Now |
| --- | --- | --- |
| `SlotController` | 5 | **11** — event locks, multi-day locks, `extend-lock`, range capacity, valid end dates |
| `WaitlistController` | 1 | **2** — `join-event-waitlist` |
| `BookingManagementController` | 3 | **5** — `increase-quantity`, `reduce-quantity` |

All legitimate. I checked the mutating ones: both quantity actions `requirePostRequest()`, take a required `token`, compare it with `hash_equals()`, and audit the failure. So the expectations are updated, not the code.

## The soft-delete tests could only pass on a UTC machine

`softDelete()` stores UTC with no zone marker (Craft's DB convention). The tests parsed it with `new DateTime()`, which reads a naive string in the **server's** zone — so they failed by exactly the local offset, 7200s in Zurich summer, 3600s in winter. Nothing in `src/` parses that column (it's only tested for `NULL`), so the tests needed the fix, not the code.

## Result

Green from a cold cache: ECS, PHPStan, **2776 tests, 134 expected skips**.

**Not done here:** adding CI. A workflow would need `composer install` to work standalone, and PHPStan currently bootstraps `../../vendor` — so CI would be red on arrival for the reason above. That needs the optional soft-dependencies installed in the workflow first; worth its own change.