### PR TITLE
Catch the docs up with what the plugin actually does

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -1555,6 +1555,12 @@ Query employees, services, locations, and reservations using Craft's element que
     .serviceId(service.id)
     .orderBy('startTime ASC')
     .all() %}
+
+{# Query blackout dates. Blackout dates are not localized, so this query spans
+   every site by default — it does not need, and ignores, a site filter. #}
+{% set closures = craft.booked.blackoutDates()
+    .orderBy('startDate ASC')
+    .all() %}
 ```
 
 ### Availability Methods

--- a/EVENT_SYSTEM.md
+++ b/EVENT_SYSTEM.md
@@ -247,6 +247,72 @@ Event::on(
 );
 ```
 
+### `PaymentRefundedEvent`
+
+**Cancelable:** No
+
+Fired after a **direct** (Commerce-free) payment is refunded, in full or in
+part. Commerce-mode refunds are Commerce's own events, not this one.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `$reservationId` | int | The reservation the refund belongs to |
+| `$record` | PaymentRecord | The payment row that was refunded |
+| `$amount` | int | This refund, in the currency's minor unit (e.g. cents) |
+| `$totalRefunded` | int | Everything refunded against the payment so far, minor units |
+
+Amounts are integers in the minor unit, not floats — compare `$amount` with
+`$totalRefunded` to tell a partial refund from the one that settles the balance.
+
+```php
+use yii\base\Event;
+use anvildev\booked\events\PaymentRefundedEvent;
+use anvildev\booked\services\PaymentService;
+
+Event::on(
+    PaymentService::class,
+    PaymentService::EVENT_PAYMENT_REFUNDED,
+    function(PaymentRefundedEvent $event) {
+        $fullyRefunded = $event->totalRefunded >= $event->record->amount;
+        Craft::info(sprintf(
+            'Refunded %d (%s) on reservation %d',
+            $event->amount,
+            $fullyRefunded ? 'now fully refunded' : 'partial',
+            $event->reservationId,
+        ), 'booked');
+    }
+);
+```
+
+## Payment Gateway Events
+
+### `RegisterPaymentGatewaysEvent`
+
+**Cancelable:** No
+
+Fired once when the direct-payment gateway registry is first built. Add an
+adapter to serve a gateway other than the bundled Stripe one; adapters are
+resolved by handle.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `$gateways` | array | Adapters to register, keyed by handle |
+
+```php
+use yii\base\Event;
+use anvildev\booked\events\RegisterPaymentGatewaysEvent;
+use anvildev\booked\services\PaymentGatewayService;
+
+Event::on(
+    PaymentGatewayService::class,
+    PaymentGatewayService::EVENT_REGISTER_PAYMENT_GATEWAYS,
+    function(RegisterPaymentGatewaysEvent $event) {
+        // Must implement anvildev\booked\contracts\PaymentGatewayInterface
+        $event->gateways['mollie'] = new \my\plugin\MollieGateway();
+    }
+);
+```
+
 ## Availability Events
 
 ### `BeforeAvailabilityCheckEvent`

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ A comprehensive booking and reservation management plugin for Craft CMS, designe
 - **Waitlist Management**: Automatic waitlist with conversion when slots become available
 - **Customer Booking Limits**: Configurable limits per service to prevent overbooking
 - **Customer Self-Service Portal**: Logged-in customers can view, manage, and cancel their bookings
+- **Session Notes**: Private post-appointment notes on a booking, separate from the customer's own notes and visible only to the assigned employee and admins
+- **No-Show Tracking**: Mark a booking as a no-show, in the Control Panel or in bulk via `booked/bookings/mark-no-shows`
 - **Multi-Site Support**: Localized services with propagation across multiple sites
 - **Framework-Free Booking Wizard**: A zero-dependency, CSP-safe multi-step booking wizard (no front-end framework required) that auto-selects and skips single-option steps to shorten the path to booking; plus dedicated event-booking and customer self-service flows
 


### PR DESCRIPTION
You suspected the docs had fallen behind the features. Audited surface by surface against the code rather than by reading.

## Most of it holds up

| Surface | Result |
| --- | --- |
| Console commands | **Every** action documented |
| MCP tools | **60 declared, 60 documented** — no drift in either direction |
| Settings | All **96** documented |
| Features | Every feature has documentation somewhere |

Two of my own probes over-reported and are worth flagging so the numbers aren't misread later: a settings sweep matching *property names* claimed 16 gaps, but they're documented under their **CP labels** (`waitlistConversionMinutes` → "Waitlist Conversion Minutes", `stripeSecretKey` → the env-var walkthrough in `payments-setup.md`). And an MCP sweep claimed 60 undocumented because it was collecting PHP method names rather than `booked_*` tool names.

## Four real gaps — all from features that landed after the surrounding docs

**`EVENT_SYSTEM.md` was missing both payment events.**

- `EVENT_PAYMENT_REFUNDED` — fires after a direct (Commerce-free) refund. Its amounts are **integers in the currency's minor unit**, not floats, which is worth stating explicitly since every other money value in these docs is a float. Documented how to tell a partial refund from the settling one.
- `EVENT_REGISTER_PAYMENT_GATEWAYS` — the extension point for adding a gateway beyond the bundled Stripe adapter. Had no documentation anywhere.

**The README feature list never gained two shipped features.** Verified against the code, not the changelog:

- **Session Notes** — gated on admin-or-assigned-employee in `bookings/edit.twig` *and* again in `BookingsController`'s write path.
- **No-Show Tracking** — settable from the `MarkAsNoShow` element action as well as `booked/bookings/mark-no-shows`.

**`craft.booked.blackoutDates()`** was the only Twig query method documented nowhere. Noted that it spans all sites, since blackout dates aren't localized.

## Scope

Documentation only — no `.php`, no behaviour change. Note `composer check` is red on `main` for reasons unrelated to this; #95 fixes that.