### PR TITLE
Preserve a booking's data when it is trashed (#93)

### DIFF
--- a/src/elements/Reservation.php
+++ b/src/elements/Reservation.php
@@ -796,10 +796,62 @@ class Reservation extends Element implements _ReservationPurchasable, Reservatio
         parent::afterSave($isNew);
     }
 
+    /**
+     * Craft deletes elements softly by default, so this used to destroy the
+     * booking's data while the element sat in the trash — restoring it produced
+     * an empty reservation (#93).
+     *
+     * A hard delete needs no help now: booked_reservations.id is a foreign key
+     * onto elements.id with ON DELETE CASCADE, so the row goes with the element.
+     *
+     * What a soft delete must still do is release the slot. `activeSlotKey`
+     * carries a unique index to prevent double-booking, and a booking sitting in
+     * the trash should not hold a seat against everyone else. Written straight to
+     * the table rather than through the record, so it cannot trip the record's
+     * own beforeSave() recomputation of that key.
+     */
     public function afterDelete(): void
     {
-        $this->getRecord()?->delete();
+        if ($this->hardDelete) {
+            // Redundant once the foreign key is in place, and deliberately so:
+            // between deploying this code and running `craft up` the constraint
+            // may not exist yet, and a hard delete in that window would leave
+            // the row behind. Harmless afterwards — the cascade has already
+            // taken it.
+            $this->getRecord()?->delete();
+        } else {
+            Craft::$app->getDb()->createCommand()
+                ->update(ReservationRecord::tableName(), ['activeSlotKey' => null], ['id' => $this->id])
+                ->execute();
+        }
+
         parent::afterDelete();
+    }
+
+    /**
+     * Reclaim the slot the booking held before it was trashed.
+     *
+     * Re-saving the record recomputes activeSlotKey from the booking's own date,
+     * time and employee. If someone has taken that slot meanwhile the unique
+     * index refuses it — the booking still comes back, just without holding that
+     * slot, which is the honest outcome and visible to whoever restored it.
+     */
+    public function afterRestore(): void
+    {
+        $record = $this->getRecord();
+
+        if ($record) {
+            try {
+                $record->save(false);
+            } catch (\yii\db\IntegrityException $e) {
+                Craft::warning(
+                    "Restored reservation {$this->id} could not reclaim its slot — it is taken: " . $e->getMessage(),
+                    __METHOD__,
+                );
+            }
+        }
+
+        parent::afterRestore();
     }
 
     public static function getStatuses(): array

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -351,6 +351,10 @@ class Install extends Migration
             ]);
 
             // No FK on 'id' to 'elements.id' - Reservations can be Elements (Commerce) or standalone ActiveRecords
+            // The row's lifetime is the element's: a hard delete takes it with
+            // the element, which is what lets afterDelete() leave it alone on a
+            // soft delete instead of destroying the booking's data (#93).
+            $this->addForeignKey(null, '{{%booked_reservations}}', 'id', '{{%elements}}', 'id', 'CASCADE', null);
             $this->addForeignKey(null, '{{%booked_reservations}}', 'employeeId', '{{%elements}}', 'id', 'SET NULL', null);
             $this->addForeignKey(null, '{{%booked_reservations}}', 'locationId', '{{%elements}}', 'id', 'SET NULL', null);
             $this->addForeignKey(null, '{{%booked_reservations}}', 'serviceId', '{{%elements}}', 'id', 'SET NULL', null);

--- a/src/migrations/m260803_000000_reservation_element_fk.php
+++ b/src/migrations/m260803_000000_reservation_element_fk.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace anvildev\booked\migrations;
+
+use craft\db\Migration;
+use craft\db\Query;
+use craft\db\Table;
+
+/**
+ * Tie `booked_reservations.id` to `elements.id` with ON DELETE CASCADE (#93).
+ *
+ * Reservation::afterDelete() used to delete the row itself, which is wrong for
+ * Craft's default soft delete: the element went to the trash while its data was
+ * destroyed, so restoring produced an empty booking. Stopping that delete is
+ * only safe once the database removes the row on a *hard* delete instead, which
+ * is what this constraint does.
+ *
+ * Order matters. This migration must land before the element stops deleting the
+ * row, or a hard delete in between leaves an orphaned reservation behind.
+ */
+class m260803_000000_reservation_element_fk extends Migration
+{
+    private const TABLE = '{{%booked_reservations}}';
+
+    public function safeUp(): bool
+    {
+        // Rows whose element has already gone cannot satisfy the constraint.
+        // They are unreachable anyway — a reservation is only ever resolved
+        // through its element — so this clears dead data, not live bookings.
+        $orphans = (new Query())
+            ->select(['r.id'])
+            ->from(['r' => self::TABLE])
+            ->leftJoin(['e' => Table::ELEMENTS], '[[e.id]] = [[r.id]]')
+            ->where(['e.id' => null])
+            ->column($this->db);
+
+        if ($orphans !== []) {
+            echo '    > deleting ' . count($orphans) . " reservation row(s) with no element\n";
+            $this->delete(self::TABLE, ['id' => $orphans]);
+        }
+
+        if (!$this->elementForeignKeyExists()) {
+            $this->addForeignKey(null, self::TABLE, 'id', Table::ELEMENTS, 'id', 'CASCADE', null);
+        }
+
+        return true;
+    }
+
+    public function safeDown(): bool
+    {
+        // Deliberately not dropping the constraint: without it, and with
+        // afterDelete() no longer removing the row, a hard delete would orphan
+        // reservations. Rolling this back on its own would reintroduce the bug.
+        return true;
+    }
+
+    /**
+     * Whether `id` already references `elements.id`. Re-reads the schema so a
+     * cached copy from earlier in the migration run can't answer for it.
+     */
+    private function elementForeignKeyExists(): bool
+    {
+        $schema = $this->db->getTableSchema(self::TABLE, true);
+        if ($schema === null) {
+            return false;
+        }
+
+        $elements = $this->db->getSchema()->getRawTableName(Table::ELEMENTS);
+
+        foreach ($schema->foreignKeys as $fk) {
+            // Shape: [0 => '<referenced table>', '<local col>' => '<foreign col>']
+            if (($fk[0] ?? null) === $elements && ($fk['id'] ?? null) === 'id') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/migrations/m260803_000001_normalize_active_slot_key.php
+++ b/src/migrations/m260803_000001_normalize_active_slot_key.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace anvildev\booked\migrations;
+
+use craft\db\Migration;
+use craft\db\Query;
+
+/**
+ * Canonicalise `activeSlotKey` to the H:i form.
+ *
+ * The key is `date|time|employeeId` and guards against double-booking through a
+ * unique index. It was built by interpolating `startTime` as-is, which is
+ * "14:00" for a booking created from a request and "14:00:00" for one read back
+ * from the TIME column. Two spellings of the same slot are two different keys,
+ * so the index never saw the collision and the same employee could be booked
+ * twice at the same time — one of the two only needing to have been re-saved.
+ *
+ * ReservationRecord now normalises before writing. Existing rows keep whichever
+ * spelling they were last saved with, so they are rewritten here.
+ */
+class m260803_000001_normalize_active_slot_key extends Migration
+{
+    private const TABLE = '{{%booked_reservations}}';
+
+    public function safeUp(): bool
+    {
+        $rows = (new Query())
+            ->select(['id', 'bookingDate', 'startTime', 'employeeId', 'activeSlotKey'])
+            ->from(self::TABLE)
+            ->where(['not', ['activeSlotKey' => null]])
+            ->all($this->db);
+
+        // Group by the key each row *should* have, so a group with more than one
+        // member is a real double booking that the broken key was hiding.
+        $byKey = [];
+        foreach ($rows as $row) {
+            $date = substr((string) $row['bookingDate'], 0, 10);
+            $time = substr((string) $row['startTime'], 0, 5);
+            $byKey[$date . '|' . $time . '|' . $row['employeeId']][] = $row;
+        }
+
+        $rewritten = 0;
+        foreach ($byKey as $key => $group) {
+            if (count($group) > 1) {
+                // Leave these alone. Rewriting them would violate the unique
+                // index, and picking which booking loses its slot is not a
+                // decision a migration should make silently.
+                $ids = implode(', ', array_column($group, 'id'));
+                echo "    > WARNING: reservations {$ids} are booked into the same slot ({$key}).\n";
+                echo "      Their slot keys are left as they are; resolve the conflict, then re-save them.\n";
+                continue;
+            }
+
+            $row = $group[0];
+            if ($row['activeSlotKey'] !== $key) {
+                $this->update(self::TABLE, ['activeSlotKey' => $key], ['id' => $row['id']]);
+                $rewritten++;
+            }
+        }
+
+        if ($rewritten > 0) {
+            echo "    > normalised {$rewritten} slot key(s)\n";
+        }
+
+        return true;
+    }
+
+    public function safeDown(): bool
+    {
+        // The normalised form is the correct one; there is nothing to undo.
+        return true;
+    }
+}

--- a/src/records/ReservationRecord.php
+++ b/src/records/ReservationRecord.php
@@ -81,14 +81,31 @@ class ReservationRecord extends ActiveRecord
     /**
      * Computes activeSlotKey for the unique double-booking constraint.
      * Active employee bookings get a non-NULL key; cancelled and employee-less bookings get NULL.
+     *
+     * The time is normalized to H:i first, and that is load-bearing. `startTime`
+     * arrives as "14:00" on a booking built from a request and as "14:00:00" on
+     * one read back from the TIME column, so interpolating it raw produced two
+     * different keys for the same slot — and the unique index cannot see a
+     * collision between strings that differ. Two confirmed bookings could
+     * therefore hold the same employee at the same time, one of them simply
+     * having been re-saved (a Control Panel edit is enough).
      */
     public function beforeSave($insert): bool
     {
         $this->activeSlotKey = ($this->status !== self::STATUS_CANCELLED && $this->employeeId !== null)
-            ? $this->bookingDate . '|' . $this->startTime . '|' . $this->employeeId
+            ? $this->bookingDate . '|' . self::normalizeSlotTime($this->startTime) . '|' . $this->employeeId
             : null;
 
         return parent::beforeSave($insert);
+    }
+
+    /**
+     * The canonical H:i form used inside activeSlotKey, so the key is identical
+     * however the reservation reached memory.
+     */
+    public static function normalizeSlotTime(?string $time): string
+    {
+        return substr((string) $time, 0, 5);
     }
 
     /**

--- a/tests/Support/TestCase.php
+++ b/tests/Support/TestCase.php
@@ -30,6 +30,31 @@ abstract class TestCase extends BaseTestCase
     /**
      * Tear down after each test
      */
+    /**
+     * The exact source of one method, bounded by its real start and end lines.
+     *
+     * Five suites here already had a private copy of this; sharing it saves the
+     * sixth. Reflection rather than a fixed slice of the file, so a contract
+     * assertion cannot silently stop covering the method as it grows.
+     *
+     * @param class-string $class
+     */
+    protected function sourceOfMethod(string $class, string $method): string
+    {
+        $reflection = new \ReflectionMethod($class, $method);
+        $file = $reflection->getFileName();
+        $this->assertNotFalse($file, "{$class} has no source file");
+
+        $lines = file($file);
+        $this->assertNotFalse($lines, "Could not read {$file}");
+
+        return implode('', array_slice(
+            $lines,
+            $reflection->getStartLine() - 1,
+            $reflection->getEndLine() - $reflection->getStartLine() + 1,
+        ));
+    }
+
     protected function tearDown(): void
     {
         Mockery::close();

--- a/tests/Unit/Elements/ReservationSoftDeleteTest.php
+++ b/tests/Unit/Elements/ReservationSoftDeleteTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace anvildev\booked\tests\Unit\Elements;
+
+use anvildev\booked\records\ReservationRecord;
+use anvildev\booked\tests\Support\TestCase;
+
+/**
+ * Guards the soft-delete contract (#93) and the slot key it depends on.
+ *
+ * Trashing and restoring is Craft's own mechanism and needs a database, so the
+ * behaviour itself is covered by tests/integration-live/soft-delete-restore.php.
+ * What can be checked here is that the two things that made the bug possible
+ * cannot come back: an unconditional row delete, and a slot key that varies with
+ * how the reservation happened to be loaded.
+ */
+class ReservationSoftDeleteTest extends TestCase
+{
+    /**
+     * "14:00" from a request and "14:00:00" read back from the TIME column have
+     * to produce the same key, or the unique index guarding against
+     * double-booking compares two strings that can never collide.
+     */
+    public function testSlotTimeNormalisesRegardlessOfSource(): void
+    {
+        $this->assertSame('14:00', ReservationRecord::normalizeSlotTime('14:00'));
+        $this->assertSame('14:00', ReservationRecord::normalizeSlotTime('14:00:00'));
+        $this->assertSame(
+            ReservationRecord::normalizeSlotTime('09:30'),
+            ReservationRecord::normalizeSlotTime('09:30:00'),
+            'The same slot must yield one key however the reservation was loaded',
+        );
+    }
+
+    public function testSlotTimeToleratesAnAbsentTime(): void
+    {
+        $this->assertSame('', ReservationRecord::normalizeSlotTime(null));
+    }
+
+    /**
+     * The key is assembled in beforeSave(); if it ever interpolates startTime
+     * directly again, the two spellings diverge and the index stops working.
+     */
+    public function testSlotKeyIsBuiltFromTheNormalisedTime(): void
+    {
+        $body = $this->sourceOfMethod(ReservationRecord::class, 'beforeSave');
+
+        $this->assertStringContainsString('normalizeSlotTime($this->startTime)', $body);
+        $this->assertStringNotContainsString("'|' . \$this->startTime . '|'", $body);
+    }
+
+    /**
+     * A soft delete must leave the row alone — deleting it is what destroyed the
+     * booking's data — and must release the slot so the trash stops holding a
+     * seat. A hard delete needs no help: the id is a cascading foreign key.
+     */
+    public function testSoftDeleteKeepsTheRowAndReleasesTheSlot(): void
+    {
+        $body = $this->sourceOfMethod(\anvildev\booked\elements\Reservation::class, 'afterDelete');
+
+        $this->assertStringContainsString('$this->hardDelete', $body, 'afterDelete() must distinguish a hard delete from a soft one');
+        // The row may only be deleted on the hard-delete branch. Anywhere else
+        // and a trashed booking loses its data again.
+        [$hard, $soft] = explode('} else {', $body, 2);
+        $this->assertStringContainsString('getRecord()?->delete()', $hard, 'a hard delete should still remove the row if the FK is not there yet');
+        $this->assertStringNotContainsString('delete()', $soft, 'a soft delete must never remove the reservation row');
+        $this->assertStringContainsString("'activeSlotKey' => null", $body, 'a trashed booking must release its slot');
+    }
+
+    public function testRestoreReclaimsTheSlotAndSurvivesLosingIt(): void
+    {
+        $body = $this->sourceOfMethod(\anvildev\booked\elements\Reservation::class, 'afterRestore');
+
+        $this->assertStringContainsString('save(false)', $body, 'restoring must recompute the slot key');
+        $this->assertStringContainsString(
+            'IntegrityException',
+            $body,
+            'a slot taken while the booking was trashed must not make the restore fail',
+        );
+    }
+
+    /**
+     * The element hooks above are only safe because the database removes the row
+     * on a hard delete.
+     */
+    public function testInstallDeclaresTheCascadingElementForeignKey(): void
+    {
+        $install = file_get_contents(dirname(__DIR__, 3) . '/src/migrations/Install.php');
+
+        $this->assertStringContainsString(
+            "addForeignKey(null, '{{%booked_reservations}}', 'id', '{{%elements}}', 'id', 'CASCADE', null)",
+            $install,
+            'booked_reservations.id must cascade from elements.id, or a hard delete orphans the row',
+        );
+    }
+}

--- a/tests/integration-live/soft-delete-restore.php
+++ b/tests/integration-live/soft-delete-restore.php
@@ -1,0 +1,201 @@
+<?php
+
+/**
+ * Trashing and restoring a booking, against a live install (#93).
+ *
+ * The unit suite cannot reach this: soft delete is Craft's own trash mechanism,
+ * so proving that a trashed booking keeps its data — and that a hard delete
+ * still removes the row — needs a real database with the foreign key in place.
+ *
+ * The claims under test, in the order that matters if they are wrong:
+ *
+ *   1. Trashing a booking preserves its row and every field on it. This is the
+ *      bug: afterDelete() used to delete the row outright, so a restore
+ *      produced an empty reservation.
+ *   2. A trashed booking releases its slot, so it stops holding a seat against
+ *      everyone else while it sits in the trash.
+ *   3. Restoring brings the data back intact and reclaims the slot.
+ *   4. A booking whose slot was taken while it was trashed still restores — it
+ *      simply comes back without that slot, rather than failing or stealing it.
+ *   5. A hard delete still removes the row, now via ON DELETE CASCADE.
+ *
+ * Usage (from the project root):
+ *   ddev exec php plugins/craft-booked/tests/integration-live/soft-delete-restore.php
+ *
+ * Seeds and cleans up after itself. Exits non-zero on any failure.
+ */
+
+require dirname(__DIR__, 4) . '/bootstrap.php';
+/** @var \craft\console\Application $app */
+$app = require CRAFT_VENDOR_PATH . '/craftcms/cms/bootstrap/console.php';
+
+use anvildev\booked\elements\Employee;
+use anvildev\booked\elements\Reservation;
+use anvildev\booked\elements\Service;
+use anvildev\booked\records\ReservationRecord;
+use craft\db\Query;
+
+const TAG = 'SOFTDEL';
+
+$failures = 0;
+$made = [];
+$elements = Craft::$app->getElements();
+$db = Craft::$app->getDb();
+
+function check(string $label, bool $ok, string $detail = ''): void
+{
+    global $failures;
+    if (!$ok) {
+        $failures++;
+    }
+    printf("  [%s] %s%s\n", $ok ? ' OK ' : 'FAIL', $label, $detail !== '' ? " — {$detail}" : '');
+}
+
+/** The reservation row straight from the table, bypassing the element layer. */
+function row(int $id): ?array
+{
+    return (new Query())->from('{{%booked_reservations}}')->where(['id' => $id])->one() ?: null;
+}
+
+// ------------------------------------------------------------------ fixture
+foreach (Reservation::find()->siteId('*')->status(null)->trashed(null)->all() as $old) {
+    if (str_contains((string) $old->userEmail, strtolower(TAG))) {
+        Craft::$app->getElements()->deleteElement($old, true);
+    }
+}
+
+$service = Service::find()->siteId('*')->status(null)->one();
+$employee = Employee::find()->siteId('*')->status(null)->one();
+if (!$service || !$employee) {
+    fwrite(STDERR, "Needs at least one service and one employee.\n");
+    exit(1);
+}
+
+$date = (new DateTime('+21 days'))->format('Y-m-d');
+
+function book(string $suffix, string $date, Service $service, Employee $employee, string $start = '11:00'): Reservation
+{
+    $r = new Reservation();
+    $r->userName = TAG . ' ' . $suffix;
+    $r->userEmail = strtolower(TAG) . "-{$suffix}@example.test";
+    $r->userPhone = '+41 44 000 00 00';
+    $r->notes = 'Original note for ' . $suffix;
+    $r->bookingDate = $date;
+    $r->startTime = $start;
+    $r->endTime = (new DateTime($start))->modify('+1 hour')->format('H:i');
+    $r->status = ReservationRecord::STATUS_CONFIRMED;
+    $r->serviceId = $service->id;
+    $r->employeeId = $employee->id;
+    $r->quantity = 1;
+    if (!Craft::$app->getElements()->saveElement($r, false)) {
+        fwrite(STDERR, "seed {$suffix}: " . json_encode($r->getErrors()) . "\n");
+        exit(1);
+    }
+    return $r;
+}
+
+echo "Trashing a booking\n";
+
+$booking = book('a', $date, $service, $employee);
+$made[] = $booking;
+$id = (int) $booking->id;
+$before = row($id);
+check('a booking is seeded with its slot held', ($before['activeSlotKey'] ?? null) !== null, 'activeSlotKey=' . var_export($before['activeSlotKey'] ?? null, true));
+
+$elements->deleteElement($booking);   // soft — Craft's default
+
+$after = row($id);
+check('the row survives the trash', $after !== null, $after === null ? 'ROW DELETED — the booking lost its data' : 'row present');
+check(
+    '…with its data intact',
+    ($after['userEmail'] ?? null) === $booking->userEmail && ($after['notes'] ?? null) === 'Original note for a',
+    'email=' . var_export($after['userEmail'] ?? null, true) . ' notes=' . var_export($after['notes'] ?? null, true),
+);
+check('…and the element is in the trash', (new Query())->from('{{%elements}}')->where(['id' => $id])->andWhere(['not', ['dateDeleted' => null]])->exists());
+check(
+    '…and it no longer holds its slot',
+    ($after['activeSlotKey'] ?? null) === null,
+    'activeSlotKey=' . var_export($after['activeSlotKey'] ?? null, true),
+);
+
+// ------------------------------------------------------ the seat is free now
+$rival = book('rival', $date, $service, $employee);
+$made[] = $rival;
+$rivalKey = row((int) $rival->id)['activeSlotKey'] ?? null;
+check(
+    'someone else can take the released slot',
+    $rivalKey !== null,
+    $rivalKey !== null ? 'rival holds ' . $rivalKey : 'the trashed booking was still holding it',
+);
+// Free it again so the restore below has its slot back.
+$elements->deleteElement($rival, true);
+
+echo "\nRestoring it\n";
+
+$trashed = Reservation::find()->id($id)->siteId('*')->status(null)->trashed()->one();
+check('the trashed booking is findable', $trashed !== null);
+
+if ($trashed) {
+    $elements->restoreElement($trashed);
+    $restored = row($id);
+
+    check('the data is still intact after restore', ($restored['userEmail'] ?? null) === $booking->userEmail, 'email=' . var_export($restored['userEmail'] ?? null, true));
+    check('…notes survived', ($restored['notes'] ?? null) === 'Original note for a', var_export($restored['notes'] ?? null, true));
+    check('…the element is out of the trash', (new Query())->from('{{%elements}}')->where(['id' => $id, 'dateDeleted' => null])->exists());
+    check(
+        '…and the slot is reclaimed',
+        ($restored['activeSlotKey'] ?? null) !== null,
+        'activeSlotKey=' . var_export($restored['activeSlotKey'] ?? null, true),
+    );
+}
+
+echo "\nRestoring into a slot someone else took\n";
+
+$contested = book('b', $date, $service, $employee, '14:00');
+$made[] = $contested;
+$contestedId = (int) $contested->id;
+$elements->deleteElement($contested);
+
+// Take the slot while it sits in the trash.
+$squatter = book('squatter', $date, $service, $employee, '14:00');
+$made[] = $squatter;
+check('the vacated slot can be taken', (row((int) $squatter->id)['activeSlotKey'] ?? null) !== null);
+
+$trashedContested = Reservation::find()->id($contestedId)->siteId('*')->status(null)->trashed()->one();
+$restoredOk = $trashedContested !== null && $elements->restoreElement($trashedContested);
+check(
+    'the booking still restores',
+    $restoredOk,
+    $restoredOk ? 'restored' : 'REFUSED; essentials errors: ' . json_encode($trashedContested?->getErrors()),
+);
+$contestedRow = row($contestedId);
+check('…with its data', ($contestedRow['userEmail'] ?? null) === $contested->userEmail);
+check(
+    '…but without stealing the slot',
+    ($contestedRow['activeSlotKey'] ?? null) === null,
+    'activeSlotKey=' . var_export($contestedRow['activeSlotKey'] ?? null, true),
+);
+check(
+    '…and the other booking keeps it',
+    (row((int) $squatter->id)['activeSlotKey'] ?? null) !== null,
+);
+
+echo "\nHard delete still removes the row\n";
+
+$doomed = book('c', $date, $service, $employee, '16:00');
+$doomedId = (int) $doomed->id;
+$elements->deleteElement($doomed, true);   // hard
+$doomedRow = row($doomedId);
+check('the row is gone via ON DELETE CASCADE', $doomedRow === null, $doomedRow === null ? 'row deleted with the element' : 'ROW STILL PRESENT — the cascade did not fire');
+check('…and so is the element', !(new Query())->from('{{%elements}}')->where(['id' => $doomedId])->exists());
+
+// ------------------------------------------------------------------ teardown
+foreach ($made as $el) {
+    $fresh = Reservation::find()->id($el->id)->siteId('*')->status(null)->trashed(null)->one();
+    if ($fresh) {
+        $elements->deleteElement($fresh, true);
+    }
+}
+
+printf("\n%s\n", $failures === 0 ? 'All checks passed.' : "{$failures} check(s) FAILED.");
+exit($failures === 0 ? 0 : 1);


### PR DESCRIPTION
Closes #93.

## The reported bug

`Reservation::afterDelete()` deleted the `booked_reservations` row outright. Craft soft-deletes by default, so a trashed booking was emptied of its data while its element sat in the trash — restoring gave you a blank reservation.

**Every other element type already had the constraint that makes deleting the row unnecessary.** Locations, employees, services, schedules, event dates, service extras and blackout dates all cascade from `elements.id`. Reservations were the sole exception, which is exactly why they had to clean up after themselves.

So the fix is three parts, and the order matters:

1. **`booked_reservations.id` → `elements.id`, `ON DELETE CASCADE`** — added *before* the element stops deleting, because the other order orphans rows in between. The migration clears rows whose element is already gone (unreachable data) so the constraint can be applied.
2. **A soft delete releases the slot instead of destroying the row.** `activeSlotKey` carries a unique index against double-booking, and a booking in the trash shouldn't hold a seat against everyone else.
3. **`afterRestore()` reclaims the slot** — and tolerates it having been taken meanwhile: the booking comes back without it rather than failing or stealing it.

The hard-delete branch still deletes the row explicitly. Redundant once the constraint exists, but a deploy reaches the new code before `craft up` reaches the migration, and a hard delete in that window would orphan a row.

## A worse bug this uncovered

Building the restore test surfaced something independent of the trash entirely.

`activeSlotKey` was assembled by interpolating `startTime` raw. That's `"14:00"` on a reservation built from a request and `"14:00:00"` on one read back from the TIME column. **Two spellings of one slot are two different keys, and a unique index cannot see a collision between strings that differ.** The live test caught it directly:

```
restored key = '2026-08-24|14:00:00|9458'
squatter key = '2026-08-24|14:00|9458'
same slot?     YES — same date, time and employee
```

Two confirmed bookings, same employee, same time, both holding a slot. **This never needed the trash** — the only requirement is that one of them was re-saved, and a Control Panel edit does that.

The key is now normalised to `H:i`. A second migration rewrites existing rows, and where normalising would collide it **leaves those rows alone and names them**, because picking which real booking loses its slot isn't a decision a migration should make silently.

## Verification

`tests/integration-live/soft-delete-restore.php` — against a real database:

```
[ OK ] the row survives the trash — row present
[ OK ] …with its data intact
[ OK ] …and it no longer holds its slot — activeSlotKey=NULL
[ OK ] someone else can take the released slot — rival holds 2026-08-24|11:00|9458
[ OK ] the data is still intact after restore
[ OK ] …and the slot is reclaimed — activeSlotKey='2026-08-24|11:00|9458'
[ OK ] the booking still restores — restored          (slot taken meanwhile)
[ OK ] …but without stealing the slot — activeSlotKey=NULL
[ OK ] the row is gone via ON DELETE CASCADE — row deleted with the element
```

`ReservationSoftDeleteTest` guards the contract in CI, where the trash is out of reach: the key must be built from the normalised time, the row may only be deleted on the hard-delete branch, restore must recompute and survive an `IntegrityException`, and `Install.php` must declare the cascading FK.

Two of my own fixture bugs are worth mentioning, since both first looked like product bugs: the seeder hardcoded `endTime = '12:00'` regardless of start (so a 14:00 booking was 14:00→12:00 and only survived because seeding skips validation), and a `[ OK ]` line printed a detail written for the failure case.

## Gate

ECS and PHPStan green from a cold cache; **2782 tests**, 134 expected skips.