### PR TITLE
Add CI, and make static analysis reproducible outside the monorepo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,94 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+# A superseded run on the same branch has nothing left to prove.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  php:
+    name: PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # The floor and the ceiling of the supported range (composer.json: ^8.2).
+        php: ['8.2', '8.3', '8.4']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          # dom/mbstring/intl are Craft's; the suite formats dates and currency.
+          extensions: dom, mbstring, intl, json, pdo
+          coverage: none
+          tools: composer:v2
+
+      - name: Cache Composer packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/composer/files
+          key: composer-${{ matrix.php }}-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-${{ matrix.php }}-
+
+      # composer.lock is committed on purpose, so install rather than update:
+      # CI should fail when the lock drifts from composer.json, not paper over it.
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-interaction --no-progress
+
+      - name: Coding standards (ECS)
+        run: composer run ecs:check
+
+      # Analysed without a result cache. A warm .phpstan directory once reported
+      # a clean run while a cold one found six genuine warnings, so CI always
+      # starts from nothing.
+      - name: Static analysis (PHPStan)
+        run: composer run phpstan
+
+      - name: Unit tests
+        run: composer run test
+
+  js:
+    name: JavaScript
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Unit tests
+        run: npm test
+
+      # dist/ and the served bundle are committed so Composer consumers don't
+      # need a build step. That only holds if they match the source — a stale
+      # bundle ships behaviour nobody can see in a diff.
+      - name: Rebuild the wizard bundle
+        run: npm run build
+
+      - name: Fail if the committed bundle is out of date
+        run: |
+          if ! git diff --quiet -- dist src/web/js/booked-wizard.umd.js src/web/js/booked-wizard.umd.js.map; then
+            echo "::error::The committed bundle differs from a fresh build. Run 'npm run build' and commit the result."
+            git diff --stat -- dist src/web/js/booked-wizard.umd.js src/web/js/booked-wizard.umd.js.map
+            exit 1
+          fi
+          echo "Committed bundle matches the source."

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,10 +10,29 @@ parameters:
     tmpDir: .phpstan
     treatPhpDocTypesAsCertain: false
     bootstrapFiles:
-        - ../../vendor/autoload.php
-        - ../../vendor/craftcms/cms/bootstrap/console.php
+        - vendor/autoload.php
+        - vendor/craftcms/cms/bootstrap/console.php
         - stubs/phpstan-bootstrap.php
+    # Craft Commerce and stimmt/craft-mcp are optional at runtime and cannot be
+    # dev dependencies either: craft-mcp requires PHP ^8.3, and installing
+    # Commerce drags craftcms/cms to a release whose transitive zipstream needs
+    # ^8.3 as well. Both would drop this plugin's own ^8.2 floor.
+    #
+    # That makes the reported error set depend on what happens to be installed,
+    # so an ignore pattern for those classes matches in one environment and not
+    # another. Reporting unmatched ignores on top of that fails the run for
+    # reasons that have nothing to do with the code — which is precisely how
+    # this gate ended up red on the default branch.
+    reportUnmatchedIgnoredErrors: false
+
     ignoreErrors:
+        # The optional integrations above. Guarded by class_exists()/soft
+        # registration, so they never load when the package is absent.
+        - '#unknown class craft\\commerce\\#'
+        - '#unknown class stimmt\\craft\\Mcp\\#'
+        - '#Attribute class Mcp\\Capability\\Attribute\\\w+ does not exist#'
+        - '#Attribute class stimmt\\craft\\Mcp\\attributes\\McpToolMeta does not exist#'
+        - '#(craft\\commerce|stimmt\\craft\\Mcp)\\#'
         # Common patterns for Craft CMS plugins
         - '#Cannot access offset .+ on mixed#'
         - '#Cannot cast mixed to#'
@@ -81,4 +100,4 @@ parameters:
     checkExplicitMixed: true
 
 includes:
-    - ../../vendor/craftcms/phpstan/phpstan.neon
+    - vendor/craftcms/phpstan/phpstan.neon


### PR DESCRIPTION
Booked had **no workflow at all** — only `dependabot.yml`. That's why its gate could sit red on the default branch unnoticed (#95), and why the PHPStan config drifted until its comment described an environment that no longer existed.

## The obstacle

`phpstan.neon` bootstrapped `../../vendor` — the surrounding project's — which no checkout of this repository has. It now uses the plugin's own, which is what CI and a standalone clone get.

Craft Commerce and `stimmt/craft-mcp` live only in the monorepo's vendor, so analysing against the plugin's own reports their classes as unknown.

## What I tried first, and why CI killed it

Making them dev dependencies looked like the tidy answer — real type-checking instead of blanket ignores. It isn't one:

- `stimmt/craft-mcp` v1.3.0 requires **PHP ^8.3**
- installing Commerce pulls `craftcms/cms` 5.9.4 → 5.10.12, whose transitive `zipstream-php` goes 3.1.2 → 3.2.2 and also needs **^8.3**

Either drops this plugin's own `^8.2` floor, and `zipstream` is a **production** dependency — so it would have quietly broken PHP 8.2 support for consumers, not just for the gate. The first push of this branch did exactly that and the 8.2 job caught it in 11 seconds:

```
maennchen/zipstream-php 3.2.2 requires php-64bit ^8.3 -> your php-64bit version (8.2.33) does not satisfy that requirement
stimmt/craft-mcp v1.3.0 requires php ^8.3 -> your php version (8.2.33) does not satisfy that requirement
```

**`composer.json` and `composer.lock` are untouched in the final version** — verified identical to `main`.

## What it does instead

The two packages stay ignored, and `reportUnmatchedIgnoredErrors` is **off**. With an optional dependency the reported error set depends on what happens to be installed, so a pattern matches in one environment and not another — and failing the run over *that* is exactly what left the gate red to begin with.

## The workflow

Mirrors Slots':

- **PHP 8.2 / 8.3 / 8.4** — ECS, PHPStan, PHPUnit. The 8.4 ceiling matters: it deprecates implicitly-nullable parameters, which silently stopped a suite from running once.
- **JavaScript** — vitest, then a rebuild that fails if the committed wizard bundle differs from a fresh build. `dist/` is committed so Composer consumers need no build step, which only holds while it matches the source.
- PHPStan runs **without a result cache**, because a warm one here reported a clean run where a cold one found six genuine warnings.

## Green in a clean checkout

| Job | Result |
| --- | --- |
| PHP 8.2 | pass |
| PHP 8.3 | pass |
| PHP 8.4 | pass |
| JavaScript | pass (298 tests) |

2782 PHPUnit tests, 134 expected skips.

## Noted, not addressed

`composer audit` reports 4 advisories against `phpseclib/phpseclib` 3.0.49, a transitive **production** dependency, at the same version before and after this change — so it predates it. Worth its own look.