### PR TITLE
Drop the reservation foreign key — it broke Commerce-free installs

### DIFF
--- a/src/elements/Reservation.php
+++ b/src/elements/Reservation.php
@@ -813,11 +813,10 @@ class Reservation extends Element implements _ReservationPurchasable, Reservatio
     public function afterDelete(): void
     {
         if ($this->hardDelete) {
-            // Redundant once the foreign key is in place, and deliberately so:
-            // between deploying this code and running `craft up` the constraint
-            // may not exist yet, and a hard delete in that window would leave
-            // the row behind. Harmless afterwards — the cascade has already
-            // taken it.
+            // Deleting the row is this method's remaining job. A cascading
+            // foreign key was tried instead and reverted: a reservation is only
+            // an element when Commerce is enabled, so the constraint made
+            // bookings impossible to create on every Commerce-free install.
             $this->getRecord()?->delete();
         } else {
             Craft::$app->getDb()->createCommand()

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -351,10 +351,10 @@ class Install extends Migration
             ]);
 
             // No FK on 'id' to 'elements.id' - Reservations can be Elements (Commerce) or standalone ActiveRecords
-            // The row's lifetime is the element's: a hard delete takes it with
-            // the element, which is what lets afterDelete() leave it alone on a
-            // soft delete instead of destroying the booking's data (#93).
-            $this->addForeignKey(null, '{{%booked_reservations}}', 'id', '{{%elements}}', 'id', 'CASCADE', null);
+            // No id -> elements.id constraint here, unlike every other element
+            // table: a reservation is only a Craft element when Commerce is
+            // enabled. Without it the row is a plain ActiveRecord with nothing
+            // in `elements`, and the constraint would reject it outright.
             $this->addForeignKey(null, '{{%booked_reservations}}', 'employeeId', '{{%elements}}', 'id', 'SET NULL', null);
             $this->addForeignKey(null, '{{%booked_reservations}}', 'locationId', '{{%elements}}', 'id', 'SET NULL', null);
             $this->addForeignKey(null, '{{%booked_reservations}}', 'serviceId', '{{%elements}}', 'id', 'SET NULL', null);

--- a/src/migrations/m260803_000002_drop_reservation_element_fk.php
+++ b/src/migrations/m260803_000002_drop_reservation_element_fk.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace anvildev\booked\migrations;
+
+use craft\db\Migration;
+use craft\db\Table;
+
+/**
+ * Drop the `booked_reservations.id` -> `elements.id` constraint added in #93.
+ *
+ * It assumed every reservation is a Craft element. Only half of them are:
+ * {@see \anvildev\booked\factories\ReservationFactory::isElementMode()} returns
+ * `isCommerceEnabled()`, so an install without Commerce — which is most of them,
+ * direct Stripe payments existing precisely so Commerce is not required — stores
+ * reservations as plain ActiveRecords with no row in `elements` at all. The
+ * constraint rejected every one of those inserts, which meant no bookings could
+ * be created on those installs.
+ *
+ * Nothing is lost by removing it. Reservation::afterDelete() already deletes the
+ * row itself on a hard delete, which is the job the cascade was doing; the rest
+ * of the soft-delete fix — preserving the row, releasing the slot, reclaiming it
+ * on restore — never depended on the constraint.
+ */
+class m260803_000002_drop_reservation_element_fk extends Migration
+{
+    private const TABLE = '{{%booked_reservations}}';
+
+    public function safeUp(): bool
+    {
+        $schema = $this->db->getTableSchema(self::TABLE, true);
+        if ($schema === null) {
+            return true;
+        }
+
+        $elements = $this->db->getSchema()->getRawTableName(Table::ELEMENTS);
+
+        // The constraint was created with a generated name, so it has to be
+        // found by what it points at rather than by what it is called.
+        foreach ($schema->foreignKeys as $name => $fk) {
+            if (($fk[0] ?? null) === $elements && ($fk['id'] ?? null) === 'id') {
+                echo "    > dropping foreign key {$name}\n";
+                $this->dropForeignKey((string) $name, self::TABLE);
+            }
+        }
+
+        return true;
+    }
+
+    public function safeDown(): bool
+    {
+        // Restoring it would reintroduce the bug on every Commerce-free install.
+        return true;
+    }
+}

--- a/tests/Unit/Elements/ReservationSoftDeleteTest.php
+++ b/tests/Unit/Elements/ReservationSoftDeleteTest.php
@@ -80,17 +80,20 @@ class ReservationSoftDeleteTest extends TestCase
     }
 
     /**
-     * The element hooks above are only safe because the database removes the row
-     * on a hard delete.
+     * A cascading id -> elements.id constraint looks like the tidy way to make
+     * afterDelete() unnecessary, and was briefly added. It cannot be used here:
+     * a reservation is only a Craft element when Commerce is enabled, so on a
+     * Commerce-free install the row has no `elements` counterpart and the
+     * constraint rejects every insert — no booking can be created at all.
      */
-    public function testInstallDeclaresTheCascadingElementForeignKey(): void
+    public function testInstallDoesNotConstrainReservationsToElements(): void
     {
         $install = file_get_contents(dirname(__DIR__, 3) . '/src/migrations/Install.php');
 
-        $this->assertStringContainsString(
-            "addForeignKey(null, '{{%booked_reservations}}', 'id', '{{%elements}}', 'id', 'CASCADE', null)",
+        $this->assertStringNotContainsString(
+            "addForeignKey(null, '{{%booked_reservations}}', 'id', '{{%elements}}'",
             $install,
-            'booked_reservations.id must cascade from elements.id, or a hard delete orphans the row',
+            'Reservations must not be constrained to elements — they are plain records without Commerce',
         );
     }
 }

--- a/tests/integration-live/soft-delete-restore.php
+++ b/tests/integration-live/soft-delete-restore.php
@@ -17,7 +17,7 @@
  *   3. Restoring brings the data back intact and reclaims the slot.
  *   4. A booking whose slot was taken while it was trashed still restores — it
  *      simply comes back without that slot, rather than failing or stealing it.
- *   5. A hard delete still removes the row, now via ON DELETE CASCADE.
+ *   5. A hard delete still removes the row — afterDelete() does it explicitly.
  *
  * Usage (from the project root):
  *   ddev exec php plugins/craft-booked/tests/integration-live/soft-delete-restore.php
@@ -186,8 +186,55 @@ $doomed = book('c', $date, $service, $employee, '16:00');
 $doomedId = (int) $doomed->id;
 $elements->deleteElement($doomed, true);   // hard
 $doomedRow = row($doomedId);
-check('the row is gone via ON DELETE CASCADE', $doomedRow === null, $doomedRow === null ? 'row deleted with the element' : 'ROW STILL PRESENT — the cascade did not fire');
+check('the row is gone', $doomedRow === null, $doomedRow === null ? 'afterDelete removed it' : 'ROW STILL PRESENT');
 check('…and so is the element', !(new Query())->from('{{%elements}}')->where(['id' => $doomedId])->exists());
+
+// ------------------------- a reservation is not always a Craft element
+// ReservationFactory returns a plain ActiveRecord when Commerce is absent, and
+// that row has nothing in `elements`. A cascading id -> elements.id constraint
+// was briefly added here and made every one of those inserts fail, so no
+// booking could be created at all on a Commerce-free install. This is the
+// check that catches it.
+echo "\nBookings without Commerce (plain records)\n";
+
+$viaFactory = \anvildev\booked\factories\ReservationFactory::create();
+echo '    factory returns ' . get_class($viaFactory) . ' (element mode: '
+    . (\anvildev\booked\factories\ReservationFactory::isElementMode() ? 'yes' : 'no') . ")\n";
+
+$viaFactory->userName = TAG . ' factory';
+$viaFactory->userEmail = strtolower(TAG) . '-factory@example.test';
+$viaFactory->bookingDate = $date;
+$viaFactory->startTime = '18:00';
+$viaFactory->endTime = '19:00';
+$viaFactory->status = ReservationRecord::STATUS_CONFIRMED;
+$viaFactory->serviceId = $service->id;
+$viaFactory->quantity = 1;
+
+$saveError = null;
+$saved = false;
+try {
+    $saved = $viaFactory->save(false);
+} catch (\Throwable $e) {
+    $saveError = get_class($e) . ': ' . $e->getMessage();
+}
+check(
+    'a booking saves through the factory',
+    $saved && $saveError === null,
+    $saveError !== null ? substr($saveError, 0, 140) : 'id=' . $viaFactory->getId(),
+);
+
+if ($viaFactory->getId()) {
+    $fRow = row((int) $viaFactory->getId());
+    check('…and its row is there', $fRow !== null);
+    // A plain record has no element to delete, so the row goes directly. (An
+    // earlier version passed a blank Reservation to deleteElement(), which is
+    // meaningless and threw from Craft's structure behaviour.)
+    if ($viaFactory instanceof Reservation) {
+        $elements->deleteElement($viaFactory, true);
+    } else {
+        Craft::$app->getDb()->createCommand()->delete('{{%booked_reservations}}', ['id' => $viaFactory->getId()])->execute();
+    }
+}
 
 // ------------------------------------------------------------------ teardown
 foreach ($made as $el) {


### PR DESCRIPTION
**Regression in #93 (merged, unreleased).** Found while checking whether the dependency refresh broke anything — it hadn't, but this had.

## What breaks

#93 added `booked_reservations.id` as a cascading foreign key onto `elements.id`, reasoning that every other element table here has one.

**A reservation is not always an element.** `ReservationFactory::isElementMode()` returns `isCommerceEnabled()`:

| Commerce | Reservation is | Row in `elements`? |
| --- | --- | --- |
| enabled | `Reservation` element | yes |
| **absent** | `ReservationModel`, a plain ActiveRecord | **no** |

So on any install without Commerce the constraint rejected every insert:

```
SQLSTATE[23000]: Integrity constraint violation: 1452 Cannot add or update a child row:
a foreign key constraint fails (`booked_reservations`, CONSTRAINT `fk_…`
FOREIGN KEY (`id`) REFERENCES `elements` (`id`) ON DELETE CASCADE)
```

**No booking could be created at all** — and that's most installs, since direct Stripe payments exist precisely so Commerce isn't required. This dev site is one of them, which is how it surfaced: `schedule-capacity` and `schedule-capacity-regression` both died on the constraint.

Unreleased — latest tag is `v1.4.6` — so no user has it.

## Why I missed it

The two paths look identical from the element side. My soft-delete tests construct a `Reservation` directly, so they never went through the factory. And I read the Install migration's other foreign keys as a pattern to follow rather than asking why reservations had been left out of it. **They had been left out for exactly this reason.**

## The fix costs nothing

Nothing in #93 depended on the constraint. `afterDelete()` already deletes the row itself on a hard delete — I'd added that as a stopgap for the window between deploying and running `craft up`, and it's now simply the mechanism. Preserving the row on a soft delete, releasing the slot, and reclaiming it on restore are all untouched.

A migration drops the constraint (found by what it points at, since the name was generated), `Install.php` no longer creates it, and the unit test that asserted it now asserts its absence with the reason.

## Verification

The live suite now creates a booking **through the factory** and asserts it saves — the check that would have caught this. It fails without this change.

```
Bookings without Commerce (plain records)
    factory returns anvildev\booked\models\ReservationModel (element mode: no)
  [ OK ] a booking saves through the factory — id=18644
  [ OK ] …and its row is there
```

| Suite | Before | After |
| --- | --- | --- |
| `schedule-capacity` | **FK violation** | 34 passed, 0 failed |
| `schedule-capacity-regression` | **FK violation** | 42 passed, 0 failed |
| `soft-delete-restore` | passed | passed (all of #93 intact) |
| `soft-lock-capacity` | passed | passed |

`composer check` green from a cold cache; 2782 tests, 134 expected skips.