### PR TITLE
Stop the upgrade path deleting every booking

### DIFF
--- a/src/migrations/m260803_000000_reservation_element_fk.php
+++ b/src/migrations/m260803_000000_reservation_element_fk.php
@@ -3,77 +3,34 @@
 namespace anvildev\booked\migrations;
 
 use craft\db\Migration;
-use craft\db\Query;
-use craft\db\Table;
 
 /**
- * Tie `booked_reservations.id` to `elements.id` with ON DELETE CASCADE (#93).
+ * Intentionally does nothing. Kept so installs that already applied it are not
+ * asked to run something else under this name.
  *
- * Reservation::afterDelete() used to delete the row itself, which is wrong for
- * Craft's default soft delete: the element went to the trash while its data was
- * destroyed, so restoring produced an empty booking. Stopping that delete is
- * only safe once the database removes the row on a *hard* delete instead, which
- * is what this constraint does.
+ * It originally added booked_reservations.id as a cascading foreign key onto
+ * elements.id, and — because the constraint cannot be added while rows violate
+ * it — deleted every reservation with no matching element first.
  *
- * Order matters. This migration must land before the element stops deleting the
- * row, or a hard delete in between leaves an orphaned reservation behind.
+ * That premise was wrong, and destructively so. A reservation is only a Craft
+ * element when Commerce is enabled
+ * ({@see \anvildev\booked\factories\ReservationFactory::isElementMode()}). On
+ * an install without Commerce *every* reservation is a plain ActiveRecord with
+ * nothing in `elements`, so this would have deleted every booking on the site
+ * and then added a constraint that made new ones impossible to create.
+ *
+ * The constraint itself is removed by m260803_000002. Neither ever reached a
+ * release: v1.4.6 predates both, so no upgrade path runs the original.
  */
 class m260803_000000_reservation_element_fk extends Migration
 {
-    private const TABLE = '{{%booked_reservations}}';
-
     public function safeUp(): bool
     {
-        // Rows whose element has already gone cannot satisfy the constraint.
-        // They are unreachable anyway — a reservation is only ever resolved
-        // through its element — so this clears dead data, not live bookings.
-        $orphans = (new Query())
-            ->select(['r.id'])
-            ->from(['r' => self::TABLE])
-            ->leftJoin(['e' => Table::ELEMENTS], '[[e.id]] = [[r.id]]')
-            ->where(['e.id' => null])
-            ->column($this->db);
-
-        if ($orphans !== []) {
-            echo '    > deleting ' . count($orphans) . " reservation row(s) with no element\n";
-            $this->delete(self::TABLE, ['id' => $orphans]);
-        }
-
-        if (!$this->elementForeignKeyExists()) {
-            $this->addForeignKey(null, self::TABLE, 'id', Table::ELEMENTS, 'id', 'CASCADE', null);
-        }
-
         return true;
     }
 
     public function safeDown(): bool
     {
-        // Deliberately not dropping the constraint: without it, and with
-        // afterDelete() no longer removing the row, a hard delete would orphan
-        // reservations. Rolling this back on its own would reintroduce the bug.
         return true;
-    }
-
-    /**
-     * Whether `id` already references `elements.id`. Re-reads the schema so a
-     * cached copy from earlier in the migration run can't answer for it.
-     */
-    private function elementForeignKeyExists(): bool
-    {
-        $schema = $this->db->getTableSchema(self::TABLE, true);
-        if ($schema === null) {
-            return false;
-        }
-
-        $elements = $this->db->getSchema()->getRawTableName(Table::ELEMENTS);
-
-        foreach ($schema->foreignKeys as $fk) {
-            // Shape: [0 => '<referenced table>', '<local col>' => '<foreign col>']
-            if (($fk[0] ?? null) === $elements && ($fk['id'] ?? null) === 'id') {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/tests/Unit/Elements/ReservationSoftDeleteTest.php
+++ b/tests/Unit/Elements/ReservationSoftDeleteTest.php
@@ -96,4 +96,24 @@ class ReservationSoftDeleteTest extends TestCase
             'Reservations must not be constrained to elements — they are plain records without Commerce',
         );
     }
+
+    /**
+     * No migration may delete reservation rows.
+     *
+     * One did. Adding the elements foreign key meant clearing the rows that
+     * violated it first, and on a Commerce-free install that is every booking on
+     * the site — a destructive upgrade in service of a constraint that was then
+     * reverted. Cheap to guard, catastrophic to repeat.
+     */
+    public function testNoMigrationDeletesReservations(): void
+    {
+        foreach (glob(dirname(__DIR__, 3) . '/src/migrations/*.php') as $file) {
+            $source = file_get_contents($file);
+            $this->assertDoesNotMatchRegularExpression(
+                '/(->delete\(|DELETE\s+FROM)[^;]*booked_reservations/i',
+                $source,
+                basename($file) . ' deletes reservation rows',
+            );
+        }
+    }
 }


### PR DESCRIPTION
**Data-loss landmine on `main`, unreleased.** Found while establishing what a release would actually contain.

## What would have happened

`m260803_000000` added the `elements` foreign key. A constraint can't be added while rows violate it, so it deleted every reservation with no matching element first:

```php
$orphans = … LEFT JOIN elements … WHERE e.id IS NULL;
$this->delete('{{%booked_reservations}}', ['id' => $orphans]);
```

On an install **without Commerce that is every booking on the site** — reservations are only Craft elements when Commerce is enabled. Verified directly here:

```
factory returns  : anvildev\booked\models\ReservationModel
saved            : yes (id=18753)
has elements row : NO
```

So upgrading from 1.4.6 would have: wiped the bookings table → added a constraint that made new bookings impossible (#101) → dropped that constraint again. **Destroying the data for nothing.**

Neither migration has been released; `v1.4.6` predates both.

## The fix

`m260803_000000` becomes a no-op rather than being deleted, so installs that already applied it aren't asked to run something different under the same name. `m260803_000002` still removes the constraint for those installs.

## Replayed the upgrade to prove it

Seeded a booking the way a Commerce-free install stores them — no `elements` row — then rewound all three `m260803_*` migrations and ran them again as a 1.4.6 install would:

```
seeded plain-record booking id=18754 (elements row: no)
*** applied m260803_000000_reservation_element_fk
*** applied m260803_000001_normalize_active_slot_key
*** applied m260803_000002_drop_reservation_element_fk

plain-record booking after upgrade : SURVIVED (id=18754)
element FKs on reservations        : locationId, employeeId, serviceId — all SET NULL
```

The `id` constraint is gone; the three that remain are unrelated and pre-existing.

## Guarded

A new test asserts **no migration contains a delete against `booked_reservations`**. Cheap to check, catastrophic to repeat.

`composer check` green from a cold cache; 2783 tests, 134 expected skips.