### PR TITLE
Release 1.4.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,38 @@ jobs:
       - name: Unit tests
         run: composer run test
 
+  stripe-floor:
+    name: Stripe SDK floor
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: dom, mbstring, intl, json, pdo
+          coverage: none
+          tools: composer:v2
+
+      # The Stripe SDK range spans v13–v21 so Booked can be installed next to
+      # plugins that cap it lower (Freeform at ^15, Formie at ^16, Commerce
+      # Stripe at ^13). The lock pins the ceiling, so nothing else in CI would
+      # notice the floor breaking — this job is the only thing holding that
+      # promise up, together with tests/Unit/StripeSdkSurfaceTest.php.
+      - name: Install the lowest supported Stripe SDK
+        run: |
+          composer install --prefer-dist --no-interaction --no-progress
+          composer update stripe/stripe-php --prefer-lowest --with-all-dependencies --no-interaction --no-progress
+          composer show stripe/stripe-php | head -2
+
+      - name: Static analysis (PHPStan)
+        run: composer run phpstan
+
+      - name: Unit tests
+        run: composer run test
+
   js:
     name: JavaScript
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 1.4.7 - 2026-08-13
+
+### Added
+- **Booking data can be imported from the Slots plugin.** Slots is Booked's smaller sibling — the same availability engine and booking wizard with the integrations stripped out — and a site that outgrows it now has a way in: `php craft booked/import/from-slots [--dry-run] [--append] [--prefix=]`. Both plugins install into the same Craft project under different table prefixes, so the command reads Slots' tables directly; there is no export file, and Slots need not be uninstalled first. It imports services, staff, locations, schedules, blackout dates, their join rows, bookings and payments in one transaction, and refuses to run when Booked already holds data unless `--append` is given (#87).
+
+### Fixed
+- **Booked installs again next to plugins that cap the Stripe SDK lower.** Booked required `stripe/stripe-php` `^21.0`, which no version of Solspace Freeform accepts — Freeform 5 caps the same SDK at `^15`, Formie at `^16`, and Craft Commerce's Stripe gateway at `^13` — so Composer refused the install with "found stripe/stripe-php[v21.0.0, ..., v21.2.0] but these were not loaded, likely because it conflicts with another require". The requirement is now a range, `^13.0` through `^21.0`. Booked only uses Payment Intents create/retrieve, refunds create and webhook signature verification, and those signatures are identical across that range (#105).
+- **A trashed booking keeps its data.** `Reservation::afterDelete()` deleted the `booked_reservations` row outright, so a booking that was only soft-deleted was emptied of its data while its element sat in the trash, and restoring it produced a blank reservation. A soft delete now also releases the slot — a booking in the trash should not hold a seat against everyone else — and restoring reclaims it, or returns the booking without it when the slot has been taken meanwhile (#93).
+- **Two confirmed bookings could hold the same employee at the same time.** `activeSlotKey` interpolated `startTime` raw, which is `"14:00"` on a reservation built from a request and `"14:00:00"` on one read back from the `TIME` column. Two spellings of one slot are two different keys, and the unique index that guards against double-booking cannot see a collision between strings that differ — so the only requirement for a clash was that one of the two bookings had been re-saved, and a Control Panel edit is enough. The key is now normalised to `H:i`, and a migration rewrites existing rows. It leaves any genuine double bookings it uncovers alone and names them, rather than silently deciding which one loses its slot.
+
+### Security
+- **Dependency lock refreshed, clearing 84 advisories across 13 packages**, including two high-severity Craft remote-code-execution advisories, a stored XSS, and CVE-2026-55599 in phpseclib — X.509 validation follows Authority Information Access URLs, so certificate parsing can be steered into making outbound requests on the server's behalf. Nothing about what the plugin requires changed; the lock had simply never moved (#100).
+
+### Changed
+- **The Packagist archive no longer carries the whole repository.** Booked had no `.gitattributes`, so 1.4.6 shipped 180 test files, the CI workflows, the PHPStan/ECS/Rector/vitest configuration, the build script and several documents written for maintainers rather than for the people installing the plugin.
+- Documentation caught up with the code: `EVENT_SYSTEM.md` gained the two payment events it was missing — `EVENT_PAYMENT_REFUNDED`, whose amounts are integers in the currency's minor unit rather than floats, and `EVENT_REGISTER_PAYMENT_GATEWAYS`, the extension point for adding a gateway beyond the bundled Stripe one — and the README's feature list gained Session Notes and No-Show Tracking.
+
+### Internal
+- The repository has a CI workflow for the first time, running ECS, PHPStan and the test suites on PHP 8.2, 8.3 and 8.4. A `stripe-floor` job installs the lowest supported Stripe SDK and re-runs the analysis and the suite against it, because the committed lock pins the ceiling and nothing else would notice the floor breaking.
+- `m260803_000000_reservation_element_fk` is now a no-op. It added a foreign key from `booked_reservations.id` onto `elements.id` and, because a constraint cannot be added while rows violate it, deleted every reservation without a matching element first — on an install without Craft Commerce that is every booking on the site, since reservations are only Craft elements when Commerce is enabled. Neither that migration nor its removal was ever released, so no upgrade from 1.4.6 or earlier was affected, but installs tracking the default branch may have applied it (#102).
+
 ## 1.4.6 - 2026-07-30
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "microsoft/microsoft-graph": "^1.0",
         "league/oauth2-client": "^2.0",
         "twilio/sdk": "^6.0 || ^7.0 || ^8.0",
-        "stripe/stripe-php": "^21.0"
+        "stripe/stripe-php": "^13.0 || ^14.0 || ^15.0 || ^16.0 || ^17.0 || ^18.0 || ^19.0 || ^20.0 || ^21.0"
     },
     "require-dev": {
         "craftcms/phpstan": "dev-main",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "anvildev/craft-booked",
     "description": "A comprehensive booking system for Craft CMS",
     "type": "craft-plugin",
-    "version": "1.4.6",
+    "version": "1.4.7",
     "keywords": [
         "craft",
         "cms",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dc94e5d700bc4f17f6b389aa46bb9bb8",
+    "content-hash": "25e3f8b472929c1f105ce338eb70f66a",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",

--- a/tests/Unit/StripeSdkSurfaceTest.php
+++ b/tests/Unit/StripeSdkSurfaceTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace anvildev\booked\tests\Unit;
+
+use anvildev\booked\tests\Support\TestCase;
+use Stripe\Exception\SignatureVerificationException;
+use Stripe\PaymentIntent;
+use Stripe\StripeClient;
+use Stripe\Webhook;
+
+/**
+ * The Stripe SDK surface {@see \anvildev\booked\gateways\StripeGateway} stands on.
+ *
+ * composer.json accepts stripe/stripe-php v13 through v21, so Booked can be
+ * installed next to plugins that cap the same SDK lower — Freeform at ^15,
+ * Formie at ^16, Craft Commerce's Stripe gateway at ^13. The lock pins the
+ * ceiling, so nothing else in the suite would notice the floor breaking.
+ *
+ * These assertions are the promise that range makes. They exercise the SDK
+ * itself rather than the adapter, and reach no network: the client is built but
+ * never called, and the webhook payload is signed here.
+ */
+class StripeSdkSurfaceTest extends TestCase
+{
+    private const SECRET = 'whsec_test_surface';
+
+    public function testClientTakesABareApiKey(): void
+    {
+        // StripeGateway::client() passes the secret key as a string, not a config array.
+        $client = new StripeClient('sk_test_surface');
+
+        $this->assertInstanceOf(StripeClient::class, $client);
+    }
+
+    /**
+     * @dataProvider serviceMethodProvider
+     */
+    public function testClientExposesTheServicesTheGatewayCalls(string $service, string $method): void
+    {
+        $client = new StripeClient('sk_test_surface');
+
+        $this->assertTrue(
+            method_exists($client->$service, $method),
+            "stripe-php no longer exposes {$service}->{$method}()",
+        );
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function serviceMethodProvider(): array
+    {
+        return [
+            'createPayment' => ['paymentIntents', 'create'],
+            'confirmPayment' => ['paymentIntents', 'retrieve'],
+            'refund' => ['refunds', 'create'],
+        ];
+    }
+
+    /**
+     * Both service calls pass an options array second (the idempotency key), so
+     * a one-argument signature would break the adapter without failing above.
+     *
+     * @dataProvider serviceMethodProvider
+     */
+    public function testTheServiceMethodsTakeAnOptionsArgument(string $service, string $method): void
+    {
+        $client = new StripeClient('sk_test_surface');
+        $reflection = new \ReflectionMethod($client->$service, $method);
+
+        $this->assertGreaterThanOrEqual(
+            2,
+            $reflection->getNumberOfParameters(),
+            "{$service}->{$method}() no longer accepts request options",
+        );
+    }
+
+    public function testConstructEventVerifiesASignedPayload(): void
+    {
+        $payload = self::payload();
+        $event = Webhook::constructEvent($payload, self::signatureFor($payload), self::SECRET);
+
+        // Every property verifyWebhook() reads off the event.
+        $this->assertSame('evt_surface', $event->id);
+        $this->assertSame('charge.refunded', $event->type);
+        $this->assertIsArray($event->toArray());
+
+        $object = $event->data->object;
+        $this->assertIsObject($object);
+        $this->assertSame('pi_surface', $object->payment_intent);
+        $this->assertSame(500, $object->amount_refunded);
+        $this->assertSame(2000, $object->amount);
+        $this->assertSame('ch_surface', $object->id);
+    }
+
+    public function testConstructEventRejectsATamperedSignature(): void
+    {
+        $payload = self::payload();
+        $signature = self::signatureFor('{"tampered":true}');
+
+        $this->expectException(SignatureVerificationException::class);
+        Webhook::constructEvent($payload, $signature, self::SECRET);
+    }
+
+    public function testPaymentIntentExposesTheFieldsTheAdapterReads(): void
+    {
+        $intent = PaymentIntent::constructFrom([
+            'id' => 'pi_surface',
+            'status' => 'succeeded',
+            'amount' => 2000,
+            'client_secret' => 'pi_surface_secret',
+        ]);
+
+        $this->assertSame('pi_surface', $intent->id);
+        $this->assertSame('succeeded', $intent->status);
+        $this->assertSame(2000, $intent->amount);
+        $this->assertSame('pi_surface_secret', $intent->client_secret);
+        $this->assertSame('pi_surface', $intent->toArray()['id']);
+    }
+
+    private static function payload(): string
+    {
+        return json_encode([
+            'id' => 'evt_surface',
+            'object' => 'event',
+            'type' => 'charge.refunded',
+            'data' => [
+                'object' => [
+                    'id' => 'ch_surface',
+                    'object' => 'charge',
+                    'payment_intent' => 'pi_surface',
+                    'amount' => 2000,
+                    'amount_refunded' => 500,
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR);
+    }
+
+    /** A `Stripe-Signature` header for the payload, built the way Stripe builds it. */
+    private static function signatureFor(string $payload): string
+    {
+        $timestamp = time();
+        $hash = hash_hmac('sha256', "{$timestamp}.{$payload}", self::SECRET);
+
+        return "t={$timestamp},v1={$hash}";
+    }
+}


### PR DESCRIPTION
Cuts 1.4.7. The release is driven by #105: Booked required `stripe/stripe-php ^21`, which no version of Solspace Freeform accepts, so the two plugins could not be installed in the same project.

## The Stripe fix

`stripe/stripe-php` is one shared package, so the lowest ceiling in the project wins:

| Plugin | Ceiling |
|---|---|
| Craft Commerce Stripe gateway | `^13` |
| Solspace Freeform 5 | `^15` |
| Verbb Formie | `^16` |
| Booked 1.4.6 | `^21` only |

The requirement is now the range `^13.0` through `^21.0`. The adapter only uses Payment Intents create/retrieve, refunds create and `Webhook::constructEvent`, and those signatures are identical across it.

Verified by resolving Booked and Freeform 5.15 together in a scratch project with a path repo. Before the change it reproduces the reported error exactly; after it locks `stripe-php v15.10.0`. PHPStan and the suite give identical results at v13.0.0 and v21.1.1.

`StripeSdkSurfaceTest` is new because the rest of the suite never touches the SDK — a floor job alone would have proved almost nothing. It pins the client services the gateway calls, their options argument, and a real signed-payload round trip through `constructEvent`. No network. The `stripe-floor` CI job installs the lowest supported SDK and re-runs the analysis and the suite against it, because the committed lock pins the ceiling.

## Also in this release

`main` carried ten commits since v1.4.6 with no changelog entries. They are documented here rather than shipped silently — the Slots import command (#87), the soft-delete data-loss fix and the `activeSlotKey` collision it uncovered (#93), the dependency lock refresh clearing 84 advisories (#100), and the packaging fix.

The Slots importer is a new feature and would ordinarily take a minor bump. Shipping it under a patch is a deliberate call, made so the Stripe fix reaches a blocked user now.

## Known: the 8.4 job is a false green

Unrelated to this PR and already true on `main`. On PHP 8.4 an implicit-nullable parameter in `tests/Unit/Services/AvailabilityCapacityTest.php:61` stops the file loading, and PHPUnit exits 0, so the `PHP 8.4` job reports success while running zero tests. 8.2 and 8.3 genuinely run 2803 tests. A follow-up fixes both the deprecations and the exit code.