### PR TITLE
Make the PHP 8.4 gate run the tests it claims to run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Internal
+- **The PHP 8.4 CI job was reporting success while running no tests at all.** An implicit-nullable parameter in `AvailabilityCapacityTest` stopped the file loading on 8.4, which took down the whole run before the first test — and PHPUnit exited 0 anyway, so the job went green. The exit code came from Yii: it defaults `silentExitOnException` to `YII_ENV_TEST`, so an uncaught throwable renders and returns rather than exiting non-zero. The suite now turns that off, and a run that dies while loading its test files fails. Verified both ways: a clean run still exits 0, and a deliberately reintroduced load failure exits 1.
+- The suite's error handler now ignores `E_DEPRECATED` raised from files under `vendor/`. `phpunit.xml` sets `error_reporting` to `-1` and Yii turns anything in that mask into an exception, so on 8.4 every implicit-nullable parameter in a package we do not own became fatal — `craft\console\Controller::output(string $string = null)` is one, still present in Craft 5.10.13.2, and it took down six tests that load a console controller. Deprecations in Booked's own code stay fatal.
+
 ## 1.4.7 - 2026-08-13
 
 ### Added

--- a/tests/Support/TestErrorHandler.php
+++ b/tests/Support/TestErrorHandler.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace anvildev\booked\tests\Support;
+
+use yii\console\ErrorHandler;
+
+/**
+ * The suite's error handler.
+ *
+ * Yii turns any error inside the `error_reporting()` mask into an exception, and
+ * phpunit.xml sets that mask to -1. On PHP 8.4 that makes every implicit-nullable
+ * parameter fatal — including the ones in packages we do not own. Craft's own
+ * `craft\console\Controller::output(string $string = null)` is one, still present
+ * in 5.10.13.2, and loading any console controller of ours through it took six
+ * tests down with it.
+ *
+ * Silencing deprecations wholesale would have hidden ours too, so this narrows it
+ * to the one thing we cannot fix: E_DEPRECATED raised from a file under vendor/.
+ * Our own deprecations stay fatal.
+ */
+class TestErrorHandler extends ErrorHandler
+{
+    /**
+     * @param int $code
+     * @param string $message
+     * @param string $file
+     * @param int $line
+     * @return bool
+     */
+    #[\ReturnTypeWillChange]
+    public function handleError($code, $message, $file, $line)
+    {
+        if ($code === E_DEPRECATED && self::isVendorFile($file)) {
+            // Handled: tell PHP not to run its internal handler either.
+            return true;
+        }
+
+        return parent::handleError($code, $message, $file, $line);
+    }
+
+    private static function isVendorFile(string $file): bool
+    {
+        return str_starts_with($file, CRAFT_VENDOR_PATH . DIRECTORY_SEPARATOR);
+    }
+}

--- a/tests/Unit/Services/AvailabilityCapacityTest.php
+++ b/tests/Unit/Services/AvailabilityCapacityTest.php
@@ -58,7 +58,7 @@ class AvailabilityCapacityTest extends TestCase
     }
 
     /** @param array<array{start: string, end: string}> $bookings */
-    private function subtract(array $windows, array $bookings, ?int $capacity, Service $service = null): array
+    private function subtract(array $windows, array $bookings, ?int $capacity, ?Service $service = null): array
     {
         return $this->invoke('subtractBookingsFromWindows', [
             $windows,

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -32,6 +32,15 @@ $config = [
     'basePath' => CRAFT_BASE_PATH,
     'vendorPath' => CRAFT_VENDOR_PATH,
     'components' => [
+        // Yii defaults silentExitOnException to YII_ENV_TEST, which is true here.
+        // An uncaught throwable then renders and returns, leaving the exit code at
+        // 0 — so a suite that dies while loading its test files reports success and
+        // CI goes green having run nothing. Turned off so the run fails loudly.
+        // See TestErrorHandler for the deprecations that used to kill it.
+        'errorHandler' => [
+            'class' => anvildev\booked\tests\Support\TestErrorHandler::class,
+            'silentExitOnException' => false,
+        ],
         'i18n' => [
             'class' => 'yii\i18n\I18N',
             'translations' => [


### PR DESCRIPTION
The `PHP 8.4` job has been reporting success while running **no tests at all**. It is green on every run in the history, including the one for #107.

## What was happening

`AvailabilityCapacityTest` declared `Service $service = null`. PHP 8.4 deprecates that, `phpunit.xml` sets `error_reporting` to `-1`, and Yii turns anything in that mask into an exception — so the file could not be loaded and the run died before the first test.

PHPUnit then exited **0**. That part comes from Yii: `ErrorHandler::$silentExitOnException` defaults to `YII_ENV_TEST`, which `tests/bootstrap.php` sets, so an uncaught throwable is rendered and then *returned from* rather than exited on. The step succeeded, the job succeeded, and 2803 tests never ran.

## The fix

Three things, because fixing only the parameter would have left the gate just as blind the next time something failed to load:

1. The parameter is now `?Service`.
2. `silentExitOnException` is off, so a run that dies while loading its test files fails.
3. `E_DEPRECATED` from files under `vendor/` is ignored, via `tests/Support/TestErrorHandler`. Craft's own `craft\console\Controller::output(string $string = null)` is deprecated on 8.4 and is **still unfixed in 5.10.13.2**, so loading any console controller of ours through it took six more tests down. Silencing deprecations wholesale would have hidden Booked's own, so this narrows it to the one thing we cannot fix.

## Verification

Both directions, on PHP 8.4:

| | before | after |
|---|---|---|
| clean run | exit 0, **0 tests** | exit 0, **2813 tests**, 5155 assertions |
| load failure | exit **0** | exit **1** |

The load-failure row is a real positive control, not an assumption — a throwaway test file with an implicit-nullable parameter was added, run, and removed. 2813 on 8.4 matches 8.2 plus the ten `StripeSdkSurfaceTest` cases from #107.

ECS, PHPStan and the 298 JS tests are unchanged and green.