### PR TITLE
Release 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.5.0 - 2026-08-18
 
 ### Fixed
 - **A schedule's capacity now applies to employees, not only to services without them.** Issue #85 taught the availability calculation to keep a slot open until every seat of the day's capacity was taken, but only where the service had no employees. A slot belonging to an employee kept exactly one seat, so a schedule set to three still closed after the first booking. Where the capacity sat on the service's schedule the numbers disagreed with what the calendar did: the slot reported three free seats and vanished anyway, because the employee's booking was cut out of their working hours before the seats were ever counted. A booking on the service being offered now takes one seat of the employee's capacity, and a booking that employee holds on any *other* service still blocks their whole range — someone busy elsewhere cannot host a seat here. Seats are counted per employee, matching how capacity already works per service, so two employees on a capacity-3 schedule offer six seats in parallel rather than three shared ones. Merged "any available" slots now report the seats of every employee behind them rather than of whichever one came first, and a party booking is measured against seats instead of head count (#109).

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "anvildev/craft-booked",
     "description": "A comprehensive booking system for Craft CMS",
     "type": "craft-plugin",
-    "version": "1.4.7",
+    "version": "1.5.0",
     "keywords": [
         "craft",
         "cms",


### PR DESCRIPTION
Version bump and changelog date for 1.5.0. No code changes.

## What ships

| PR | |
|---|---|
| #108 | The PHP 8.4 CI job was green while running no tests (already on `main`) |
| #110 | A schedule's capacity applies to employee slots, not only to services without employees |
| #111 | Wizard id matching, the add-on flag, and two dead guards |

## Why minor rather than patch

#110 changes booking behaviour on any site that has set a capacity: a slot belonging to an employee used to take one booking and now takes as many as the schedule grants. Sites that never set a capacity are unaffected — blank still means one booking per slot, pinned by guards in the live suite.

No migrations, so `schemaVersion` stays at 1.4.1.

## Verification

2828 PHP tests, 301 JS tests, PHPStan clean, ECS unchanged (its 16 findings are pre-existing test files). All seven live integration suites pass against a real database: employee-slot-capacity (27), service-list-extras (5), schedule-capacity (34), schedule-capacity-regression (42), soft-lock-capacity (3), soft-delete-restore, dependency-surface.

Both feature branches were also driven through the booking wizard in a real browser across the full configuration matrix — capacity unset/1/2/3/30, zero/one/two employees, schedule on the service or the employee or both, buffers, add-ons and all three duration types.