### PR TITLE
Release 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
 # Changelog
 
-## Unreleased
+## 1.5.1 - 2026-08-18
 
 ### Fixed
 - **An employee-less booking cost a whole time slot instead of a seat.** On a service whose schedule sits on the service rather than its staff, `removeUnassignedBookingSlots()` dropped one slot per booking without an employee — and after deduplication there is one slot per time, so a single such booking erased every seat behind it. A two-employee capacity-3 service lost all six. Those seats were already charged by the capacity enrichment, so the filter was subtracting the same booking a second time and far more bluntly; it is gone, and both schedule placements now agree that one booking costs one seat.
-
 - **A party larger than the slot could be offered and then refused.** The quantity filter only ran on the employee-schedule path; the two service-schedule branches never received the requested quantity at all, so a capacity-3 slot was offered for a party of eight and the booking service turned it away. Every path now withholds a slot no single employee can seat. Found while checking the capacity table in `AVAILABILITY.md` against the code.
 - **`selectEventDate()` accepted a string id the way `selectService()` used to.** 1.5.0 normalised ids in the service, location and employee selectors but left the fourth, so an integrator passing an event date id straight from a URL got a selection that matched nothing. The shipped event template never emits one, so no site could hit it — the fix keeps the four selectors consistent rather than repairing a live fault. The wizard's constructor normalises its `serviceId` option too, so `getState()` reports a number before `start()` has resolved the service.
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "anvildev/craft-booked",
     "description": "A comprehensive booking system for Craft CMS",
     "type": "craft-plugin",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "keywords": [
         "craft",
         "cms",


### PR DESCRIPTION
Version bump and changelog date for 1.5.1. No code changes.

## What ships

All of it from #113:

| | |
|---|---|
| **Fixed** | An employee-less booking cost a whole time slot instead of a seat — one such booking erased all six seats of a two-employee capacity-3 service |
| **Fixed** | A party larger than the slot could be offered and then refused; the quantity filter never ran on the two service-schedule paths |
| **Fixed** | `selectEventDate()` accepted a string id the way `selectService()` used to (not reachable from shipped templates — a consistency fix) |
| **Changed** | Availability resolves each employee's schedule once per request instead of three times |
| **Changed** | `AVAILABILITY.md` describes capacity as it actually behaves |

## Why a patch

Both bugs fail closed — a slot is offered and the booking refused, or a slot disappears — so neither could oversell or corrupt data. Correctly-working setups see no behaviour change; the optimisation is internal. No migrations, so `schemaVersion` stays at 1.4.1.

## Measured

| | 1.5.0 | 1.5.1 |
|---|---|---|
| availability request (3 employees) | 16 queries | 12 |
| `createBooking()` | 66 queries | 48 |
| reservation save, in a loop | 3.0 per save | 1.4 |

## Verification

2828 PHP tests, 303 JS tests, PHPStan clean, ECS unchanged. All eight live integration suites pass against a real database, including the new `schedule-cache-invalidation.php` — the memo is cleared on every assignment write, on `Schedule` save/delete, and by `clearServiceScheduleCache()`, and each of those routes was verified by removing the invalidation it guards and watching the test fail.

Also driven through the booking wizard in a real browser across all 17 booking scenarios the plugin offers — appointments with and without staff, add-ons, buffers, multi-day, flexible-day, events, the event waitlist, manage-and-cancel, party bookings, and a Control Panel capacity edit landing in the customer calendar on the next request. No product defect found.