### PR TITLE
Document the queue worker the notifications have always needed

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -76,6 +76,8 @@ Supports reCAPTCHA v3, hCaptcha, and Cloudflare Turnstile. Select a provider in 
 | Email Reminder Hours Before | 24 | |
 | Send Cancellation Email | Yes | |
 
+Booked queues all emails. A queue worker must run, or the emails go out only when a person opens the control panel — see [Queue Setup](QUEUE.md).
+
 Reminders require a cron job — see [Console Commands](CONSOLE_COMMANDS.md).
 
 ---
@@ -305,6 +307,7 @@ In the CP settings fields, reference these as `$GOOGLE_CALENDAR_CLIENT_ID` etc.
 
 ## Next Steps
 
+- [Queue Setup](QUEUE.md) - Run a queue worker so notifications go out immediately
 - [Email Templates](EMAIL_TEMPLATES.md) - Customize email notifications
 - [Developer Guide](DEVELOPER_GUIDE.md) - API reference and extension guide
 - [Event System](EVENT_SYSTEM.md) - Hook into the booking lifecycle

--- a/CONSOLE_COMMANDS.md
+++ b/CONSOLE_COMMANDS.md
@@ -149,6 +149,8 @@ php craft booked/reminders/send   # Send pending reminders synchronously
 php craft booked/reminders/queue  # Queue reminders for async processing (recommended for cron)
 ```
 
+`booked/reminders/queue` only puts the reminders in the queue. A queue worker must run to send them — see [Queue Setup](QUEUE.md).
+
 ## Waitlist
 
 ```bash

--- a/EMAIL_TEMPLATES.md
+++ b/EMAIL_TEMPLATES.md
@@ -18,6 +18,8 @@ The plugin sends these email types automatically:
 
 All emails are sent asynchronously via Craft's queue system. Confirmation emails include an `.ics` calendar attachment.
 
+A queue worker must run on the server — see [Queue Setup](QUEUE.md). Without a worker, the emails stay in the queue until a person opens the control panel.
+
 ---
 
 ## Customizing Templates

--- a/QUEUE.md
+++ b/QUEUE.md
@@ -1,0 +1,180 @@
+# Queue Setup
+
+Booked sends its emails, SMS messages, webhooks, and calendar updates through the **Craft queue**. The queue holds each job until a worker runs it.
+
+**Set up a queue worker on your server.** Without a worker, the jobs stay in the queue. They run only when a person opens the control panel.
+
+> **Symptom of a missing worker:** a customer books on the front end, but the confirmation email comes much later. It comes at the moment when a person opens the control panel.
+
+---
+
+## Why a Worker Is Necessary
+
+The Craft setting `runQueueAutomatically` is `true` by default. With this default, Craft runs the pending jobs from control panel requests only. Front-end requests do not run the queue.
+
+A booking from the front end therefore waits for the next control panel visit. This is standard Craft behaviour. It applies to each plugin that uses the queue.
+
+---
+
+## What Booked Puts in the Queue
+
+| Job | Trigger |
+|-----|---------|
+| Booking confirmation email | A customer completes a booking |
+| Owner notification email | A customer completes a booking |
+| Cancellation email | A person cancels a booking |
+| Status change email | An admin changes the booking status |
+| Quantity change email | An admin changes the number of places |
+| SMS message | A confirmation, a reminder, or a cancellation, if Twilio is on |
+| Calendar sync | A booking is created, changed, or cancelled |
+| Webhook delivery | Each subscribed booking event |
+| Waitlist notification | A place becomes free |
+| Reminder batch | The `booked/reminders/queue` command |
+
+Booked pushes the confirmation email and the owner notification with priority `512`. The Craft default is `1024`. A smaller number runs first. The emails therefore go before the calendar sync and the webhooks.
+
+---
+
+## Option 1: A Daemon (Recommended)
+
+A daemon gives the fastest delivery. The worker stays in memory and looks for new jobs every 3 seconds.
+
+**Step 1.** Stop the control panel queue runner:
+
+```php
+// config/general.php
+return [
+    '*' => [
+        'runQueueAutomatically' => false,
+    ],
+];
+```
+
+**Step 2.** Start the worker with a process monitor.
+
+Supervisor:
+
+```ini
+; /etc/supervisor/conf.d/craft-queue.conf
+[program:craft-queue]
+command=php /path/to/project/craft queue/listen --verbose
+directory=/path/to/project
+user=www-data
+autostart=true
+autorestart=true
+numprocs=1
+redirect_stderr=true
+stdout_logfile=/var/log/craft-queue.log
+```
+
+```bash
+sudo supervisorctl reread
+sudo supervisorctl update
+sudo supervisorctl status craft-queue
+```
+
+systemd:
+
+```ini
+# /etc/systemd/system/craft-queue.service
+[Unit]
+Description=Craft queue worker
+After=network.target
+
+[Service]
+User=www-data
+WorkingDirectory=/path/to/project
+ExecStart=/usr/bin/php /path/to/project/craft queue/listen --verbose
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now craft-queue
+sudo systemctl status craft-queue
+```
+
+One worker process is sufficient for most sites. Restart the worker after each deployment. New code does not go into a process that is already in memory.
+
+---
+
+## Option 2: A Cron Job (Simple)
+
+Use a cron job if you cannot run a daemon:
+
+```
+* * * * * cd /path/to/project && php craft queue/run >/dev/null 2>&1
+```
+
+The `queue/run` command runs the waiting jobs and then stops. An email comes after a maximum delay of one minute.
+
+Set `runQueueAutomatically` to `false` for this option also. The control panel then stays quick.
+
+---
+
+## Managed Hosting
+
+Craft Cloud runs the queue for you. No worker setup is necessary.
+
+Other managed platforms frequently supply a queue worker. Read the documentation of your host, and switch the worker on.
+
+---
+
+## Reminders Need a Cron Job Also
+
+The worker sends the reminder emails, but a cron job must find the due reminders first. The two are not the same task.
+
+```
+0 * * * * cd /path/to/project && php craft booked/reminders/queue >/dev/null 2>&1
+```
+
+See [Console Commands](CONSOLE_COMMANDS.md) for the reminder commands.
+
+---
+
+## Verify the Setup
+
+Look at the queue:
+
+```bash
+php craft booked/doctor   # Shows the number of waiting jobs
+php craft queue/info      # Shows the waiting, delayed, reserved, and done jobs
+```
+
+Then do a test:
+
+1. Make a test booking on the front end.
+2. Do not open the control panel.
+3. The confirmation email must come in some seconds (daemon) or in one minute (cron).
+
+If the number of waiting jobs increases and does not decrease, the worker does not run.
+
+For local development with DDEV, run the worker in a second terminal:
+
+```bash
+ddev exec php craft queue/listen --verbose
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Action |
+|---------|-------|--------|
+| The emails come only after a control panel visit | No worker runs | Set up option 1 or option 2 |
+| The number of waiting jobs increases | The worker stopped | Examine the process monitor and `/var/log/craft-queue.log` |
+| A job failed in **Utilities → Queue Manager** | The job caused an error | Read `storage/logs/queue.log`, then run `php craft queue/retry all` |
+| The queue is empty, but no email comes | The Craft mail settings are incorrect | Run `php craft booked/doctor` |
+| The emails come twice | Two workers run | Stop one worker, and set `runQueueAutomatically` to `false` |
+
+---
+
+## Next Steps
+
+- [Email Templates](EMAIL_TEMPLATES.md) - Customize the email notifications
+- [Console Commands](CONSOLE_COMMANDS.md) - CLI commands for reminders, cleanup, and diagnostics
+- [Configuration Guide](CONFIGURATION.md) - Complete configuration reference

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ A comprehensive booking and reservation management plugin for Craft CMS, designe
 - PHP 8.2 or later
 - MySQL 8.0.17+ or PostgreSQL 13+
 - Composer
+- A queue worker (daemon or cron) for the background jobs - see [Queue Setup](QUEUE.md)
 
 ## Quick Start
 
@@ -75,6 +76,7 @@ ddev php craft plugin/install booked
 
 ### Setup & Configuration
 - [Configuration Guide](CONFIGURATION.md) - Complete configuration reference
+- [Queue Setup](QUEUE.md) - **Required** - Run a queue worker so emails, SMS, and webhooks go out immediately
 
 ### Core Features
 - [Availability & Schedule System](AVAILABILITY.md) - Complete guide to how availability and schedules work

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -288,6 +288,8 @@ You should be redirected to the confirmation page.
 
 ## Step 6: Set Up Email Notifications (Optional)
 
+> **Before you start:** Booked queues its emails. Set up a queue worker on the server, or the emails go out only when a person opens the control panel. See [Queue Setup](QUEUE.md).
+
 ### Enable Confirmation Emails
 
 1. Go to **Booked → Settings** in the sidebar, then click the **Notifications** tab
@@ -340,6 +342,7 @@ You now have a working booking system. Here's where to go next:
 
 ### Learn More
 
+- [Queue Setup](QUEUE.md) - Run a queue worker so notifications go out immediately
 - [Availability System](AVAILABILITY.md) - Understand how schedules and slots work
 - [Developer Guide](DEVELOPER_GUIDE.md) - Full API reference
 - [Event System](EVENT_SYSTEM.md) - Hook into booking lifecycle
@@ -364,6 +367,7 @@ You now have a working booking system. Here's where to go next:
 
 ### Emails not sending
 
+- Check a queue worker is running - Booked queues all emails, see [Queue Setup](QUEUE.md)
 - Check Craft's email settings are configured
 - Verify notifications are enabled in Booked settings
 - Check the Craft logs for email errors


### PR DESCRIPTION
Refs #114.

## The report

#114 says booking emails go out only after somebody visits the admin interface. That is accurate, and it is standard Craft behaviour rather than a defect: `runQueueAutomatically` defaults to `true`, and with that default Craft runs pending jobs from control-panel requests only. Front-end requests never run the queue, so a booking made on the front end waits for the next CP visit.

## Why it reaches us as a bug report

Booked routes every notification through the queue — `BookingNotificationService` pushes the confirmation, owner, cancellation, status-change and quantity-change emails, plus SMS and calendar sync; `WebhookService`, `WaitlistService` and `RemindersController` push the rest. Nothing in the docs said a worker was required. `README.md`, `TUTORIAL.md`, `CONFIGURATION.md`, `EMAIL_TEMPLATES.md` and `CONSOLE_COMMANDS.md` mentioned neither `queue/listen`, `queue/run` nor `runQueueAutomatically`. An installer following the tutorial end to end had no way to learn this.

## The change

New `QUEUE.md`:

- why a worker is necessary, stated as Craft behaviour that applies to every queueing plugin
- what Booked puts in the queue, and the priority `512` the confirmation and owner emails use
- a Supervisor and a systemd daemon, behind `'runQueueAutomatically' => false`
- the once-a-minute cron alternative
- managed hosting, and the separate `booked/reminders/queue` cron
- verification with `php craft booked/doctor` and `php craft queue/info`, plus a front-end test that does not touch the CP
- a troubleshooting table covering a stopped worker, a failed job, an empty queue with no mail, and duplicate workers

The five docs above now link to it, and the README lists a queue worker under Requirements.

## Notes

- Docs only. No source change.
- The commands are checked against `craftcms/cms` 5 in `vendor/`: `queue/info` is the default action of `craft\queue\Command`, `queue/run` and `queue/listen [timeout=3]` are its worker actions, and `queue/retry` accepts `all`.
- No `Closes` keyword, so merging leaves #114 open for a reply.
- No CHANGELOG entry — that is written on the release branch here.